### PR TITLE
Add Sora Metrics dashboard (like-rate vs unique)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 ﻿[![License: Polyform Noncommercial 1.0.0](https://img.shields.io/badge/license-Polyform%20Noncommercial%201.0.0-blue.svg)](./LICENSE)
 
-# Sora Explore - Unique Views
+# Sora Explore - Unique Views + Metrics Dashboard
 
 Shows unique view counts right on Sora Explore, profile grids, and post pages.
+Now also displays like rate (likes ÷ unique viewers) alongside the Unique count when available. Hover the badge to see raw likes/views.
+
+Click the extension icon to open a full-page dashboard (new tab) that lets you:
+- Type-ahead search to quickly select a user (with clear selection state)
+- See a colorized scatter/line chart of Like Rate (Y) vs Unique Viewers (X) over time for each post
+- Hover tooltips, per-post colors, and trend lines; click a point to open the post
+- Thumbnails and direct links in the post list; select up to two posts to compare
+- Export all snapshots for a user as CSV
 
 ## Load it in Chrome
 - Open `chrome://extensions`, flip on **Developer mode**.
@@ -11,7 +19,13 @@ Shows unique view counts right on Sora Explore, profile grids, and post pages.
 
 ## Use it
 - Browse Explore, your profile, or any `/p/s_*` post.
-- The extension sniffs feed responses and drops a `Unique: *` badge on each card plus a sticky badge on the post detail view.
+- The extension sniffs feed responses and drops a `Unique: *` badge on each card plus a sticky badge on the post detail view. When likes and unique viewers are present, the badge shows `Unique: <count> • <like-rate%>`. Hover to see `Likes` and `Views`.
+- When you view explore feeds or profile feeds, the extension records snapshots for each visible post: `unique`, `likes`, `views`, and a timestamp. These are stored locally in `chrome.storage.local` and power the dashboard.
+
+### Dashboard notes
+- X-axis is Unique Viewers; Y-axis is Like Rate (%). As a post reaches a broader audience, points often drift rightwards (more unique) while Y can trend down.
+- Select up to 2 posts to compare. Others remain in the background for context.
+- Data is stored locally on your machine. Clearing site data or extension storage removes it.
 - If you tweak code, just hit the **Reload** button in `chrome://extensions` to see your changes.
 
 ## Notes
@@ -22,7 +36,7 @@ Shows unique view counts right on Sora Explore, profile grids, and post pages.
 This project is licensed under the Polyform Noncommercial License 1.0.0 (see [LICENSE](./LICENSE)).
 
 - ✅ You may use, modify, and share for **noncommercial** purposes.
-- 🚫 **Commercial** use requires a separate paid license (see [LICENSE-COMMERCIAL](./LICENSE-COMMERCIAL); contact will@cruttenden.com).
+- 🚫 **Commercial** use requires a separate paid license (see [LICENSE-COMMERCIAL](./LICENSE-COMMERCIAL); contact william@cruttenden.dev).
 
 Contributions are accepted under the DCO (see [CONTRIBUTING.md](./CONTRIBUTING.md)).
 

--- a/background.js
+++ b/background.js
@@ -1,0 +1,6 @@
+/* Open full dashboard page when the action icon is clicked */
+chrome.action.onClicked.addListener(() => {
+  const url = chrome.runtime.getURL('dashboard.html');
+  chrome.tabs.create({ url });
+});
+

--- a/dashboard.css
+++ b/dashboard.css
@@ -1,0 +1,44 @@
+:root{
+  --bg:#0b0d10; --fg:#e8eaed; --muted:#a7b0ba; --panel:#14181d; --accent:#7dc4ff;
+  --grid:#25303b; --axis:#607080; --chip:#1c242c; --ok:#37d67a; --warn:#ffbd2e; --bad:#ff6464;
+}
+*{box-sizing:border-box}
+html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font:13px/1.4 system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif}
+.topbar{display:flex;align-items:center;justify-content:space-between;padding:8px 12px;border-bottom:1px solid #1f252b;background:var(--panel);position:sticky;top:0;z-index:10}
+.brand{font-weight:700;color:var(--accent)}
+.actions{display:flex;gap:8px;align-items:center}
+input[type=search], select, button{background:#0f1317;color:var(--fg);border:1px solid #1f2a33;border-radius:6px;padding:6px 8px}
+button{cursor:pointer}
+button:hover{background:#10171f}
+.user-picker{position:relative}
+.suggestions{position:absolute;top:32px;left:0;right:0;background:#0f1317;border:1px solid #1f2a33;border-radius:8px;max-height:220px;overflow:auto;display:none;z-index:20}
+.suggestions .item{padding:6px 8px;cursor:pointer;display:flex;justify-content:space-between;gap:8px}
+.suggestions .item:hover{background:#131920}
+.current-user{min-width:140px;color:var(--muted);font-size:12px}
+.layout{display:grid;grid-template-columns: 280px 1fr;min-height: calc(100vh - 44px)}
+.sidebar{border-right:1px solid #1f252b;background:#0f1317;padding:10px;overflow:auto}
+.sidebar h3{margin:6px 6px 10px;font-size:12px;color:var(--muted);font-weight:600;text-transform:uppercase}
+.posts{display:flex;flex-direction:column;gap:6px}
+.post{display:flex;align-items:center;gap:8px;padding:6px;border:1px solid #1f2a33;border-radius:8px;background:var(--chip)}
+.post.selected{border-color: var(--accent); box-shadow: 0 0 0 1px rgba(125,196,255,0.2) inset}
+.post.hidden{opacity:0.45; filter:grayscale(60%)}
+.post .toggle{margin-left:auto; font-size:11px; color:var(--muted); cursor:pointer; padding:2px 6px; border:1px solid #26313b; border-radius:999px}
+.post .toggle:hover{background:#111921}
+.post input{margin:0}
+.post .meta{display:flex;flex-direction:column;gap:2px}
+.post .thumb{width:44px;height:44px;border-radius:6px;background:#0f1317;border:1px solid #1f2a33;background-size:cover;background-position:center}
+.post .meta .id{font-family:ui-monospace, SFMono-Regular, Menlo, monospace;font-size:11px;opacity:.8}
+.post .meta .stats{font-size:11px;color:var(--muted)}
+.content{padding:10px;overflow:auto}
+.chart-wrap{border:1px solid #1f2a33;border-radius:8px;background:#0f1317;padding:8px}
+.chart-wrap canvas{width:100%;height:420px;display:block}
+.legend{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
+.chip{display:inline-flex;gap:6px;align-items:center;border:1px solid #1f2a33;background:var(--chip);border-radius:999px;padding:4px 8px;font-size:12px}
+.dot{width:10px;height:10px;border-radius:50%}
+.help{margin-top:8px;color:var(--muted)}
+.tooltip{position:fixed;pointer-events:none;background:#0d1116;border:1px solid #1f2a33;color:#e8eaed;padding:6px 8px;border-radius:8px;font-size:12px;display:none;z-index:30}
+
+@media (max-width: 900px){
+  .layout{grid-template-columns: 1fr}
+  .sidebar{order:2}
+}

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sora Metrics Dashboard</title>
+  <link rel="stylesheet" href="dashboard.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">Sora Metrics</div>
+    <div class="actions">
+      <div class="user-picker">
+        <input id="search" type="search" placeholder="Type to find user…" autocomplete="off" />
+        <div id="suggestions" class="suggestions"></div>
+      </div>
+      <select id="userSelect" title="All users"></select>
+      <button id="refresh">Refresh</button>
+      <button id="export">Export CSV</button>
+      <button id="resetZoom" title="Reset zoom to fit">Reset Zoom</button>
+      <button id="showAll" title="Show all posts">Show All</button>
+    </div>
+  </header>
+
+  <main class="layout">
+    <aside class="sidebar">
+      <h3>Posts</h3>
+      <div id="posts" class="posts"></div>
+    </aside>
+    <section class="content">
+      <div class="chart-wrap">
+        <canvas id="chart" width="900" height="540"></canvas>
+        <div id="tooltip" class="tooltip"></div>
+      </div>
+      <div class="legend" id="legend"></div>
+      <div class="help">Y: Like rate (%) • X: Unique viewers • Drag to zoom • Hover to focus series • Click point to open post • Toggle visibility in the left list</div>
+    </section>
+  </main>
+
+  <script src="dashboard.js"></script>
+</body>
+</html>

--- a/dashboard.js
+++ b/dashboard.js
@@ -1,0 +1,435 @@
+/* Dashboard for Sora Metrics */
+(function(){
+  'use strict';
+
+  const $ = (sel, el=document) => el.querySelector(sel);
+  const $$ = (sel, el=document) => Array.from(el.querySelectorAll(sel));
+  const SITE_ORIGIN = 'https://sora.chatgpt.com';
+  const absUrl = (u, pid) => {
+    if (!u && pid) return `${SITE_ORIGIN}/p/${pid}`;
+    if (!u) return null;
+    if (/^https?:\/\//i.test(u)) return u;
+    if (u.startsWith('/')) return SITE_ORIGIN + u;
+    return SITE_ORIGIN + '/' + u;
+  };
+  const COLORS = [
+    '#7dc4ff','#ff8a7a','#ffd166','#95e06c','#c792ea','#64d3ff','#ffa7c4','#9fd3c7','#f6bd60','#84a59d','#f28482'
+  ];
+  const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+
+  function fmt(n){
+    if (n == null || !isFinite(n)) return '-';
+    if (n >= 1e6) return (n/1e6).toFixed(n%1e6?1:0)+'M';
+    if (n >= 1e3) return (n/1e3).toFixed(n%1e3?1:0)+'K';
+    return String(n);
+  }
+
+  function likeRate(likes, uv){
+    const a = Number(likes), b = Number(uv);
+    if (!isFinite(a) || !isFinite(b) || b <= 0) return null;
+    return (a / b) * 100;
+  }
+
+  async function loadMetrics(){
+    const { metrics = { users:{} } } = await chrome.storage.local.get('metrics');
+    return metrics;
+  }
+
+  function buildUserOptions(metrics){
+    const sel = $('#userSelect');
+    sel.innerHTML = '';
+    let entries = Object.entries(metrics.users);
+    // Sort alphabetical, pushing 'unknown' to the end
+    const users = entries.sort((a,b)=>{
+      const A = (a[1].handle||a[0]||'').toLowerCase();
+      const B = (b[1].handle||b[0]||'').toLowerCase();
+      const ax = a[0]==='unknown' ? 1 : 0;
+      const bx = b[0]==='unknown' ? 1 : 0;
+      if (ax !== bx) return ax - bx;
+      return A.localeCompare(B);
+    });
+    for (const [key, u] of users){
+      const opt = document.createElement('option');
+      opt.value = key;
+      const postCount = Object.keys(u.posts||{}).length;
+      opt.textContent = `${u.handle || key} (${postCount})`;
+      sel.appendChild(opt);
+    }
+    return users.length ? users[0][0] : null;
+  }
+
+  function filterUsersByQuery(metrics, q){
+    const res = [];
+    const needle = q.trim().toLowerCase();
+    for (const [key, u] of Object.entries(metrics.users)){
+      const name = (u.handle || key || '').toLowerCase();
+      if (!needle || name.includes(needle)) res.push([key,u]);
+    }
+    res.sort((a,b)=> (a[1].handle||a[0]||'').localeCompare(b[1].handle||b[0]||''));
+    return res;
+  }
+
+  function buildPostsList(user, colorFor, visibleSet){
+    const wrap = $('#posts');
+    wrap.innerHTML='';
+    if (!user) return;
+    const posts = Object.entries(user.posts||{}).map(([pid,p])=>{
+      const last = p.snapshots?.[p.snapshots.length-1] || {};
+      const rate = likeRate(last.likes, last.uv);
+      return { pid, url: absUrl(p.url, pid), thumb: p.thumb, last, rate };
+    }).sort((a,b)=> (b.last?.t||0) - (a.last?.t||0));
+
+    for (let i=0;i<posts.length;i++){
+      const p = posts[i];
+      const row = document.createElement('label');
+      row.className='post';
+      const color = typeof colorFor === 'function' ? colorFor(p.pid) : COLORS[i % COLORS.length];
+      const thumbStyle = p.thumb ? `background-image:url('${p.thumb.replace(/'/g,"%27")}')` : '';
+      row.innerHTML = `
+        <div class="dot" style="background:${color}"></div>
+        <div class="thumb" style="${thumbStyle}"></div>
+        <div class="meta">
+          <div class="id"><a href="${p.url}" target="_blank" rel="noopener">${p.pid}</a></div>
+          <div class="stats">Unique ${fmt(p.last?.uv)} • Likes ${fmt(p.last?.likes)} • Rate ${p.rate==null?'-':p.rate.toFixed(1)+'%'}</div>
+        </div>
+        <div class="toggle" data-pid="${p.pid}">Hide</div>
+      `;
+      if (visibleSet && !visibleSet.has(p.pid)) { row.classList.add('hidden'); row.querySelector('.toggle').textContent = 'Show'; }
+      wrap.appendChild(row);
+    }
+  }
+
+  function computeSeriesForUser(user, selectedPIDs, colorFor){
+    const series=[];
+    const entries = Object.entries(user.posts||{});
+    for (let i=0;i<entries.length;i++){
+      const [pid, p] = entries[i];
+      const pts = [];
+      for (const s of (p.snapshots||[])){
+        const r = likeRate(s.likes, s.uv);
+        if (s.uv != null && r != null) pts.push({ x:s.uv, y:r, t:s.t });
+      }
+      const color = typeof colorFor === 'function' ? colorFor(pid) : COLORS[i % COLORS.length];
+      if (pts.length) series.push({ id: pid, color, points: pts, highlighted: selectedPIDs.includes(pid) });
+    }
+    return series;
+  }
+
+  function makeColorMap(user){
+    const pids = Object.keys(user.posts||{}).sort();
+    const map = new Map();
+    pids.forEach((pid, idx)=> map.set(pid, COLORS[idx % COLORS.length]));
+    return (pid) => map.get(pid) || COLORS[0];
+  }
+
+  function extent(arr, acc){
+    let lo= Infinity, hi=-Infinity;
+    for (const v of arr){
+      const x = acc(v);
+      if (x==null || !isFinite(x)) continue;
+      if (x<lo) lo=x; if (x>hi) hi=x;
+    }
+    if (lo===Infinity) lo=0; if (hi===-Infinity) hi=1;
+    if (lo===hi){ hi = hi+1; lo = Math.max(0, lo-1); }
+    return [lo,hi];
+  }
+
+  function makeChart(canvas){
+    const ctx = canvas.getContext('2d');
+    const DPR = Math.max(1, window.devicePixelRatio||1);
+    let W = canvas.clientWidth||canvas.width, H = canvas.clientHeight||canvas.height;
+    // plot area margins
+    const M = { left:50, top:20, right:30, bottom:40 };
+    function resize(){
+      W = canvas.clientWidth||canvas.width; H = canvas.clientHeight||canvas.height;
+      canvas.width = Math.floor(W*DPR); canvas.height = Math.floor(H*DPR); ctx.setTransform(DPR,0,0,DPR,0,0);
+      draw();
+    }
+    const state = { series:[], x:[0,1], y:[0,1], zoomX:null, zoomY:null, hover:null, hoverSeries:null };
+
+    function setData(series){
+      state.series = series;
+      const xs=[], ys=[];
+      for (const s of series){
+        for (const p of s.points){ xs.push(p.x); ys.push(p.y); }
+      }
+      state.x = extent(xs, d=>d);
+      state.y = extent(ys, d=>d);
+      draw();
+    }
+
+    function mapX(x){ const [a,b]=(state.zoomX||state.x); return M.left + ( (x-a)/(b-a) ) * (W - (M.left+M.right)); }
+    function mapY(y){ const [a,b]=(state.zoomY||state.y); return H - M.bottom - ( (y-a)/(b-a) ) * (H - (M.top+M.bottom)); }
+    function clampToPlot(px, py){
+      const x = Math.max(M.left, Math.min(W - M.right, px));
+      const y = Math.max(M.top, Math.min(H - M.bottom, py));
+      return [x,y];
+    }
+
+    function grid(){
+      ctx.strokeStyle = '#25303b'; ctx.lineWidth=1; ctx.setLineDash([4,4]);
+      // verticals (x)
+      for (let i=0;i<6;i++){ const x = M.left + i*(W-(M.left+M.right))/5; ctx.beginPath(); ctx.moveTo(x, M.top); ctx.lineTo(x, H - M.bottom); ctx.stroke(); }
+      // horizontals (y)
+      for (let i=0;i<6;i++){ const y = M.top + i*(H-(M.top+M.bottom))/5; ctx.beginPath(); ctx.moveTo(M.left, y); ctx.lineTo(W - M.right, y); ctx.stroke(); }
+      ctx.setLineDash([]);
+    }
+
+    function axes(){
+      const xDomain = state.zoomX || state.x;
+      const yDomain = state.zoomY || state.y;
+      ctx.strokeStyle = '#607080'; ctx.lineWidth=1.5; ctx.beginPath(); ctx.moveTo(50,20); ctx.lineTo(50,H-40); ctx.lineTo(W-30,H-40); ctx.stroke();
+      ctx.fillStyle = '#a7b0ba'; ctx.font = '12px system-ui, -apple-system, Segoe UI, Roboto, Arial';
+      // ticks
+      const xticks = 5, yticks=5;
+      for (let i=0;i<=xticks;i++){
+        const x = M.left + i*(W-(M.left+M.right))/xticks; const v = xDomain[0] + i*(xDomain[1]-xDomain[0])/xticks;
+        ctx.fillText(fmt(Math.round(v)), x-10, H - (M.bottom - 18));
+      }
+      for (let i=0;i<=yticks;i++){
+        const y = H - M.bottom - i*(H-(M.top+M.bottom))/yticks; const v = yDomain[0] + i*(yDomain[1]-yDomain[0])/yticks;
+        ctx.fillText((Math.round(v*10)/10)+'%', 10, y+4);
+      }
+      // labels
+      ctx.fillStyle = '#e8eaed'; ctx.font = 'bold 13px system-ui, -apple-system, Segoe UI, Roboto, Arial';
+      ctx.fillText('Unique viewers', W/2-50, H-6);
+      ctx.save(); ctx.translate(12, H/2+20); ctx.rotate(-Math.PI/2); ctx.fillText('Like rate (%)', 0,0); ctx.restore();
+    }
+
+    function regression(points){
+      // simple least squares y = a + b*x
+      const n = points.length; if (n < 2) return null;
+      let sx=0, sy=0, sxx=0, sxy=0;
+      for (const p of points){ sx+=p.x; sy+=p.y; sxx+=p.x*p.x; sxy+=p.x*p.y; }
+      const denom = n*sxx - sx*sx; if (denom === 0) return null;
+      const b = (n*sxy - sx*sy) / denom; const a = (sy - b*sx) / n; // slope b, intercept a
+      const xs = points.map(p=>p.x); const minX = Math.min(...xs), maxX = Math.max(...xs);
+      return { a, b, minX, maxX };
+    }
+
+    function drawSeries(){
+      const muted = '#38424c';
+      const anyHover = !!state.hoverSeries;
+      for (const s of state.series){
+        const color = (anyHover && state.hoverSeries !== s.id) ? muted : s.color;
+        // line
+        if (s.points.length>1){
+          ctx.strokeStyle = color; ctx.lineWidth = s.highlighted ? 2.2 : 1.2; ctx.beginPath();
+          s.points.sort((a,b)=>a.t-b.t);
+          for (let i=0;i<s.points.length;i++){
+            const p = s.points[i]; const x = mapX(p.x), y = mapY(p.y);
+            if (i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
+          }
+          ctx.stroke();
+          // trend line (regression)
+          const reg = regression(s.points);
+          if (reg){
+            ctx.save(); ctx.setLineDash([6,4]); ctx.strokeStyle = color; ctx.globalAlpha = 0.7; ctx.beginPath();
+            const y1 = reg.a + reg.b*reg.minX, y2 = reg.a + reg.b*reg.maxX;
+            ctx.moveTo(mapX(reg.minX), mapY(y1)); ctx.lineTo(mapX(reg.maxX), mapY(y2)); ctx.stroke(); ctx.restore();
+          }
+        }
+        // points
+        for (const p of s.points){
+          const x = mapX(p.x), y = mapY(p.y);
+          const isHover = state.hover && state.hover.pid === s.id && state.hover.i === p.t;
+          ctx.fillStyle = color; ctx.beginPath(); ctx.arc(x,y, isHover?4.2:2.4, 0, Math.PI*2); ctx.fill();
+          if (isHover){ ctx.strokeStyle = '#ffffffaa'; ctx.lineWidth=1; ctx.beginPath(); ctx.arc(x,y, 6, 0, Math.PI*2); ctx.stroke(); }
+        }
+      }
+    }
+
+    function draw(){
+      ctx.clearRect(0,0,canvas.width,canvas.height);
+      grid(); axes(); drawSeries();
+    }
+
+    // hover and click
+    const tooltip = $('#tooltip');
+    function nearest(mx,my){
+      let best=null, bd=Infinity;
+      for (const s of state.series){
+        for (const p of s.points){
+          const x = mapX(p.x), y = mapY(p.y);
+          // ignore points outside plot
+          if (x < M.left || x > W - M.right || y < M.top || y > H - M.bottom) continue;
+          const d = Math.hypot(mx-x,my-y);
+          if (d<bd && d<16) { bd=d; best = { pid: s.id, x:p.x, y:p.y, t:p.t, color:s.color, highlighted:s.highlighted, url: s.url }; }
+        }
+      }
+      return best;
+    }
+
+    function showTooltip(h, clientX, clientY){
+      if (!h){ tooltip.style.display='none'; return; }
+      tooltip.style.display='block';
+      tooltip.style.left = (clientX + 12) + 'px';
+      tooltip.style.top  = (clientY + 12) + 'px';
+      tooltip.innerHTML = `<div style="display:flex;align-items:center;gap:6px"><span class="dot" style="background:${h.color}"></span><strong>${h.pid}</strong></div>
+      <div>Unique: ${fmt(h.x)} • Rate: ${h.y.toFixed(1)}%</div>`;
+    }
+
+    // Zoom drag state
+    let drag = null; // {x0,y0,x1,y1}
+
+    canvas.addEventListener('mousemove', (e)=>{
+      const rect = canvas.getBoundingClientRect();
+      const mx = (e.clientX - rect.left) * (canvas.width/rect.width) / DPR;
+      const my = (e.clientY - rect.top) * (canvas.height/rect.height) / DPR;
+      if (drag){ drag.x1 = mx; drag.y1 = my; draw(); drawDragRect(drag); showTooltip(null); return; }
+      const h = nearest(mx,my); state.hover = h; state.hoverSeries = h?.pid || null; draw(); showTooltip(h, e.clientX, e.clientY);
+    });
+    canvas.addEventListener('mouseleave', ()=>{ state.hover=null; state.hoverSeries=null; draw(); showTooltip(null); });
+    canvas.addEventListener('click', ()=>{
+      if (state.hover && state.hover.url) window.open(state.hover.url, '_blank');
+    });
+
+    canvas.addEventListener('mousedown', (e)=>{
+      const rect = canvas.getBoundingClientRect();
+      let x0 = (e.clientX - rect.left) * (canvas.width/rect.width) / DPR;
+      let y0 = (e.clientY - rect.top) * (canvas.height/rect.height) / DPR;
+      // allow starting outside; we'll clamp on render/mouseup
+      drag = { x0, y0, x1: null, y1: null };
+    });
+    window.addEventListener('mouseup', (e)=>{
+      if (!drag) return;
+      const rect = canvas.getBoundingClientRect();
+      let x1 = (e.clientX - rect.left) * (canvas.width/rect.width) / DPR;
+      let y1 = (e.clientY - rect.top) * (canvas.height/rect.height) / DPR;
+      // clamp both ends to plot for decision and mapping
+      const [cx0, cy0] = clampToPlot(drag.x0, drag.y0);
+      const [cx1, cy1] = clampToPlot(x1, y1);
+      drag.x1 = cx1; drag.y1 = cy1; // store clamped end for consistent rectangle draw
+      const minW = 10, minH = 10;
+      const w = Math.abs(cx1 - cx0), h = Math.abs(cy1 - cy0);
+      if (w > minW && h > minH){
+        // convert to data space
+        const [X0,X1] = [cx0, cx1].sort((a,b)=>a-b);
+        const [Y0,Y1] = [cy0, cy1].sort((a,b)=>a-b);
+        const invMapX = (px)=>{ const [a,b]=(state.zoomX||state.x); return a + ( (px - M.left)/(W - (M.left+M.right)) ) * (b-a); };
+        const invMapY = (py)=>{ const [a,b]=(state.zoomY||state.y); return a + ( ( (H - M.bottom) - py)/(H - (M.top+M.bottom)) ) * (b-a); };
+        state.zoomX = [invMapX(X0), invMapX(X1)];
+        state.zoomY = [invMapY(Y1), invMapY(Y0)];
+      }
+      drag = null; draw(); showTooltip(null);
+    });
+
+    function drawDragRect(d){
+      if (!d || d.x1==null || d.y1==null) return;
+      ctx.save(); ctx.strokeStyle = '#7dc4ff'; ctx.fillStyle = '#7dc4ff22'; ctx.lineWidth=1; ctx.setLineDash([4,3]);
+      // clamp rect to plot area for rendering
+      const x0 = Math.max(M.left, Math.min(W - M.right, d.x0));
+      const y0 = Math.max(M.top,  Math.min(H - M.bottom, d.y0));
+      const x1 = Math.max(M.left, Math.min(W - M.right, d.x1));
+      const y1 = Math.max(M.top,  Math.min(H - M.bottom, d.y1));
+      const x = Math.min(x0,x1), y = Math.min(y0,y1), w = Math.abs(x1-x0), h = Math.abs(y1-y0);
+      ctx.strokeRect(x,y,w,h); ctx.fillRect(x,y,w,h); ctx.restore();
+    }
+
+    // Double-click to reset zoom
+    canvas.addEventListener('dblclick', ()=>{ state.zoomX=null; state.zoomY=null; draw(); });
+
+    window.addEventListener('resize', resize);
+    resize();
+    function resetZoom(){ state.zoomX=null; state.zoomY=null; draw(); }
+    return { setData, resetZoom };
+  }
+
+  function buildLegend(series){
+    const el = $('#legend');
+    el.innerHTML = '';
+    for (const s of series){
+      const chip = document.createElement('div');
+      chip.className = 'chip';
+      chip.innerHTML = `<div class="dot" style="background:${s.color}"></div><div>${s.id}</div>`;
+      el.appendChild(chip);
+    }
+  }
+
+  function exportCSV(user){
+    const lines = ['post_id,timestamp,unique,likes,views,like_rate'];
+    for (const [pid,p] of Object.entries(user.posts||{})){
+      for (const s of (p.snapshots||[])){
+        const rate = likeRate(s.likes, s.uv);
+        lines.push([pid, s.t, s.uv??'', s.likes??'', s.views??'', rate==null?'':rate.toFixed(4)].join(','));
+      }
+    }
+    const blob = new Blob([lines.join('\n')], {type:'text/csv'});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a'); a.href=url; a.download='sora_metrics.csv'; a.click();
+    setTimeout(()=>URL.revokeObjectURL(url), 1000);
+  }
+
+  async function main(){
+    let metrics = await loadMetrics();
+    // Build list and try to restore last user
+    let currentUserKey = buildUserOptions(metrics);
+    try {
+      const { lastUserKey } = await chrome.storage.local.get('lastUserKey');
+      if (lastUserKey && metrics.users[lastUserKey]) currentUserKey = lastUserKey;
+    } catch {}
+    const selEl = $('#userSelect'); if (currentUserKey) selEl.value = currentUserKey;
+    const chart = makeChart($('#chart'));
+    const visibleSet = new Set();
+
+    function refreshUserUI(){
+      const user = metrics.users[currentUserKey];
+      if (!user){
+        buildPostsList(null, ()=>COLORS[0], new Set()); buildLegend([]); chart.setData([]); return;
+      }
+      const colorFor = makeColorMap(user);
+      if (visibleSet.size === 0){ Object.keys(user.posts||{}).forEach(pid=>visibleSet.add(pid)); }
+      buildPostsList(user, colorFor, visibleSet);
+      const series = computeSeriesForUser(user, [], colorFor)
+        .filter(s=>visibleSet.has(s.id))
+        .map(s=>({ ...s, url: absUrl(user.posts?.[s.id]?.url, s.id) }));
+      buildLegend(series.slice(0,8));
+      chart.setData(series);
+      // wire visibility toggles
+      $$('#posts .toggle').forEach(btn=>{
+        btn.addEventListener('click', ()=>{
+          const pid = btn.dataset.pid; const row = btn.closest('.post');
+          if (visibleSet.has(pid)) { visibleSet.delete(pid); row.classList.add('hidden'); btn.textContent='Show'; }
+          else { visibleSet.add(pid); row.classList.remove('hidden'); btn.textContent='Hide'; }
+          // Fit to visible
+          chart.resetZoom();
+          chart.setData(computeSeriesForUser(user, [], colorFor).filter(s=>visibleSet.has(s.id)).map(s=>({ ...s, url: absUrl(user.posts?.[s.id]?.url, s.id) })));
+        });
+      });
+    }
+
+    $('#userSelect').addEventListener('change', async (e)=>{
+      currentUserKey = e.target.value; visibleSet.clear();
+      try { await chrome.storage.local.set({ lastUserKey: currentUserKey }); } catch {}
+      refreshUserUI();
+    });
+
+    // Typeahead suggestions
+    $('#search').addEventListener('input', (e)=>{
+      const suggestions = $('#suggestions');
+      const list = filterUsersByQuery(metrics, e.target.value).slice(0, 20);
+      suggestions.innerHTML = list.map(([key,u])=>{
+        const count = Object.keys(u.posts||{}).length;
+        return `<div class="item" data-key="${key}"><span>${u.handle||key}</span><span style="color:#7d8a96">${count} posts</span></div>`;
+      }).join('');
+      suggestions.style.display = list.length ? 'block' : 'none';
+      $$('#suggestions .item').forEach(it=>{
+        it.addEventListener('click', async ()=>{
+          currentUserKey = it.dataset.key; visibleSet.clear(); $('#search').value = ''; suggestions.style.display='none';
+          const sel = $('#userSelect'); sel.value = currentUserKey; refreshUserUI();
+          try { await chrome.storage.local.set({ lastUserKey: currentUserKey }); } catch {}
+        });
+      });
+    });
+    document.addEventListener('click', (e)=>{ if (!e.target.closest('.user-picker')) $('#suggestions').style.display='none'; });
+
+    $('#refresh').addEventListener('click', async ()=>{ metrics = await loadMetrics(); const prev = currentUserKey; const def = buildUserOptions(metrics); if (!metrics.users[prev]) currentUserKey = def; $('#userSelect').value = currentUserKey || ''; try { await chrome.storage.local.set({ lastUserKey: currentUserKey }); } catch {} refreshUserUI(); });
+    $('#export').addEventListener('click', ()=>{ const u=metrics.users[currentUserKey]; if (u) exportCSV(u); });
+    $('#resetZoom').addEventListener('click', ()=>{ chart.resetZoom(); refreshUserUI(); });
+    $('#showAll').addEventListener('click', ()=>{ const u = metrics.users[currentUserKey]; if (!u) return; visibleSet.clear(); Object.keys(u.posts||{}).forEach(pid=>visibleSet.add(pid)); chart.resetZoom(); refreshUserUI(); });
+
+    refreshUserUI();
+  }
+
+  document.addEventListener('DOMContentLoaded', main, { once:true });
+})();

--- a/inject.js
+++ b/inject.js
@@ -12,6 +12,13 @@
   const fmt = (n) => (n >= 1e6 ? (n/1e6).toFixed(n%1e6?1:0)+'M'
                     : n >= 1e3 ? (n/1e3).toFixed(n%1e3?1:0)+'K'
                     : String(n));
+  const fmtPct = (num, den) => {
+    const a = Number(num), b = Number(den);
+    if (!Number.isFinite(a) || !Number.isFinite(b) || b <= 0) return null;
+    const p = (a / b) * 100;
+    const digits = p < 10 ? 1 : 0;
+    return p.toFixed(digits) + '%';
+  };
   const normalizeId = (s) => s?.toString().split(/[?#]/)[0].trim();
   const isExplore = () => location.pathname.startsWith('/explore');
   const isProfile = () => location.pathname.startsWith('/profile');
@@ -38,6 +45,57 @@
 
   // ---------- JSON extractors ----------
   const getUniqueViews = (item) => item?.post?.unique_view_count ?? null;
+  const getLikes = (item) => {
+    try {
+      const p = item?.post ?? item;
+      const cands = [
+        p?.like_count,
+        p?.likes_count,
+        p?.likes,
+        p?.stats?.like_count,
+        p?.statistics?.like_count,
+        p?.reactions?.like?.count,
+      ];
+      for (const v of cands) if (Number.isFinite(Number(v))) return Number(v);
+    } catch {}
+    return null;
+  };
+  const getTotalViews = (item) => {
+    try {
+      const p = item?.post ?? item;
+      const cands = [
+        p?.view_count,
+        p?.views,
+        p?.play_count,
+        p?.impression_count,
+        p?.stats?.view_count,
+        p?.statistics?.view_count,
+      ];
+      for (const v of cands) if (Number.isFinite(Number(v))) return Number(v);
+    } catch {}
+    return null;
+  };
+
+  const getThumbnail = (item) => {
+    try {
+      const p = item?.post ?? item;
+      const candidates = [
+        p?.thumbnail_url,
+        p?.thumb,
+        p?.cover,
+        p?.image?.url || p?.image,
+        Array.isArray(p?.images) ? p.images[0]?.url : null,
+        p?.media?.thumbnail || p?.media?.cover || p?.media?.poster,
+        Array.isArray(p?.assets) ? p.assets[0]?.thumbnail_url || p.assets[0]?.url : null,
+        p?.preview_image_url,
+        p?.poster?.url,
+      ].filter(Boolean);
+      for (const u of candidates) {
+        if (typeof u === 'string' && /^https?:\/\//.test(u)) return u;
+      }
+    } catch {}
+    return null;
+  };
   const getItemId = (item) => {
     const cand = item?.post?.id || item?.post?.core_id || item?.post?.content_id || item?.id;
     if (cand && /^s_[A-Za-z0-9]+$/i.test(cand)) return normalizeId(cand);
@@ -60,10 +118,12 @@
   };
 
   // ---------- state & UI ----------
-  const idToViews = new Map();
+  const idToUnique = new Map();
+  const idToLikes  = new Map();
+  const idToViews  = new Map();
 
-  function addBadge(card, views) {
-    if (views == null) return;
+  function addBadge(card, unique, likes, views) {
+    if (unique == null) return;
     let badge = card.querySelector('.sora-uv-badge');
     if (!badge) {
       if (getComputedStyle(card).position === 'static') card.style.position = 'relative';
@@ -86,15 +146,35 @@
       });
       card.appendChild(badge);
     }
-    badge.textContent = `Unique: ${fmt(views)}`;
+    // Prefer unique viewers as denominator; fallback to total views
+    const denom = (unique != null && unique > 0) ? unique : ((views != null && views > 0) ? views : null);
+    const rate = (likes != null && denom != null) ? fmtPct(likes, denom) : null;
+
+    if (rate != null) {
+      badge.textContent = `Unique: ${fmt(unique)} • ${rate}`;
+    } else if (likes != null && views != null) {
+      // Fallback: show raw likes/views if we can't compute rate for some reason
+      badge.textContent = `Unique: ${fmt(unique)} • ${fmt(likes)}/${fmt(views)}`;
+    } else if (likes != null) {
+      badge.textContent = `Unique: ${fmt(unique)} • ${fmt(likes)} likes`;
+    } else if (views != null) {
+      badge.textContent = `Unique: ${fmt(unique)} • ${fmt(views)} views`;
+    } else {
+      badge.textContent = `Unique: ${fmt(unique)}`;
+    }
+    // Helpful tooltip with raw counts if available
+    const parts = [`Unique: ${fmt(unique)}`];
+    if (likes != null) parts.push(`Likes: ${fmt(likes)}`);
+    if (views != null) parts.push(`Views: ${fmt(views)}`);
+    badge.title = parts.join(' | ');
   }
 
   function renderBadges() {
     for (const card of selectAllCards()) {
       const id = extractIdFromCard(card);
       if (!id) continue;
-      const uv = idToViews.get(id);
-      if (uv != null) addBadge(card, uv);
+      const uv = idToUnique.get(id);
+      if (uv != null) addBadge(card, uv, idToLikes.get(id), idToViews.get(id));
     }
   }
 
@@ -132,10 +212,29 @@
     }
     const sid = currentSIdFromURL();
     if (!sid) return;
-    const uv = idToViews.get(sid);
+    const uv = idToUnique.get(sid);
     if (uv == null) return;
     const el = ensureDetailBadge();
-    el.textContent = `Unique: ${fmt(uv)}`;
+    const likes = idToLikes.get(sid);
+    const views = idToViews.get(sid);
+    // Prefer unique viewers as denominator; fallback to total views
+    const denom = (uv != null && uv > 0) ? uv : ((views != null && views > 0) ? views : null);
+    const rate = (likes != null && denom != null) ? fmtPct(likes, denom) : null;
+    if (rate != null) {
+      el.textContent = `Unique: ${fmt(uv)} • ${rate}`;
+    } else if (likes != null && views != null) {
+      el.textContent = `Unique: ${fmt(uv)} • ${fmt(likes)}/${fmt(views)}`;
+    } else if (likes != null) {
+      el.textContent = `Unique: ${fmt(uv)} • ${fmt(likes)} likes`;
+    } else if (views != null) {
+      el.textContent = `Unique: ${fmt(uv)} • ${fmt(views)} views`;
+    } else {
+      el.textContent = `Unique: ${fmt(uv)}`;
+    }
+    const titleParts = [`Unique: ${fmt(uv)}`];
+    if (likes != null) titleParts.push(`Likes: ${fmt(likes)}`);
+    if (views != null) titleParts.push(`Views: ${fmt(views)}`);
+    el.title = titleParts.join(' | ');
   }
 
   // ---------- observers ----------
@@ -188,13 +287,68 @@
 
   function processFeedJson(json) {
     const items = json?.items || json?.data?.items || [];
+    const batch = [];
     for (const it of items) {
       const id = getItemId(it);
       const uv = getUniqueViews(it);
-      if (id && uv != null) idToViews.set(id, uv);
+      const lk = getLikes(it);
+      const tv = getTotalViews(it);
+      const th = getThumbnail(it);
+      if (!id) continue;
+      if (uv != null) idToUnique.set(id, uv);
+      if (lk != null) idToLikes.set(id, lk);
+      if (tv != null) idToViews.set(id, tv);
+      const meta = extractUserMeta(it) || {};
+      const pf = pageFallbackUser();
+      const pageUserKey = pf?.userKey || null;
+      const pageUserHandle = pf?.userHandle || null;
+      const absUrl = `${location.origin}/p/${id}`;
+      batch.push({ postId: id, uv, likes: lk, views: tv, thumb: th, url: absUrl, pageUserKey, pageUserHandle, ...meta, ts: Date.now() });
     }
+    if (batch.length) try { window.postMessage({ __sora_uv__: true, type: 'metrics_batch', items: batch }, '*'); } catch {}
     renderBadges();
     renderDetailBadge();
+  }
+
+  function extractUserMeta(item){
+    try {
+      const p = item?.post ?? item;
+      const directHandle = p?.user_handle || p?.author_handle || p?.owner_handle || p?.creator_handle || item?.user_handle || item?.author_handle;
+      const directId = p?.user_id || p?.author_id || p?.owner_id || p?.creator_id || item?.user_id || item?.author_id;
+      let candidates = [
+        p?.user, p?.author, p?.creator, p?.owner, p?.profile, p?.channel, p?.actor,
+        item?.user, item?.author, item?.creator, item?.owner, item?.profile, item?.channel, item?.actor
+      ].filter(Boolean);
+      let handle = directHandle || null;
+      let id = directId || null;
+      for (const u of candidates){
+        if (!handle) handle = u.handle || u.username || u.user_name || u.screen_name || (typeof u.name==='string' && u.name.startsWith('@') ? u.name.slice(1) : null);
+        if (!id) id = u.id || u.user_id || u.uid || u.profile_id || u.channel_id || null;
+        if (handle && id) break;
+      }
+      // Fallback to page-level profile when available
+      if (!handle && !id) {
+        const pf = pageFallbackUser();
+        if (pf) return pf;
+      }
+      const userKey = (handle || id || '').toString().toLowerCase() || 'unknown';
+      return { userHandle: handle || null, userId: id || null, userKey };
+    } catch {}
+    return null;
+  }
+
+  function pageFallbackUser(){
+    try{
+      if (isProfile()){
+        const m = location.pathname.match(/^\/profile\/(?:@)?([^\/?#]+)/i);
+        if (m && m[1]){
+          const handle = decodeURIComponent(m[1]);
+          const key = handle.toLowerCase();
+          return { userHandle: handle, userId: null, userKey: key };
+        }
+      }
+    } catch {}
+    return null;
   }
 
   // ---------- optional bootstrap ----------

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Sora Explore - Unique Views",
-  "version": "0.4.0",
-  "description": "Overlays unique view counts on Sora Explore videos.",
+  "version": "0.6.0",
+  "description": "Overlays unique views and like rate (likes ÷ unique) on Sora Explore videos.",
   "icons": {
     "16": "icons/16.png",
     "48": "icons/48.png",
@@ -28,5 +28,9 @@
       "run_at": "document_start"
     }
   ],
-  "host_permissions": ["https://sora.chatgpt.com/*"]
+  "host_permissions": ["https://sora.chatgpt.com/*"],
+  "permissions": ["storage"],
+  "background": {
+    "service_worker": "background.js"
+  }
 }


### PR DESCRIPTION
This PR adds a full metrics dashboard to the Sora Unique Views extension.

Highlights
- Badges: Show like rate (likes ÷ unique) with raw counts on hover
- Capture: Persist snapshots (unique, likes, views, ts) per post/user in chrome.storage
- Dashboard (new tab): Typeahead user picker, thumbnails + direct links, colorized chart
- Chart UX: Hover focus, trend lines, drag-to-zoom (bounded), double-click + button reset, hide/show outliers, auto-fit
- URL fixes: Chart links and post list open full site URLs
- Persistence: Remembers last selected user across sessions

Files
- New: background.js, dashboard.html, dashboard.css, dashboard.js
- Updated: inject.js, content.js, manifest.json, README.md

Version bump: 0.6.0
