### PR TITLE
Perf: centralize metrics I/O in service worker and optimize inject.js rendering

### DIFF
--- a/background.js
+++ b/background.js
@@ -4,7 +4,622 @@ chrome.action.onClicked.addListener(() => {
   chrome.tabs.create({ url });
 });
 
-/* Listen for dashboard open requests from content script */
+/* ─── Metrics module (single owner of cache + storage writes) ─── */
+
+const PENDING = [];
+let flushTimer = null;
+const METRICS_STORAGE_KEY = 'metrics';
+const METRICS_UPDATED_AT_KEY = 'metricsUpdatedAt';
+const METRICS_USERS_INDEX_KEY = 'metricsUsersIndex';
+
+// Debug toggles
+const DEBUG = { storage: false, thumbs: false };
+const dlog = (topic, ...args) => { try { if (DEBUG[topic]) console.log('[SoraUV]', topic, ...args); } catch {} };
+
+const DEFAULT_METRICS = { users: {} };
+const postIdToUserKey = new Map();
+let metricsCache = null;
+let metricsCacheUpdatedAt = 0;
+let metricsCacheLoading = null;
+let lastSelfWriteTs = 0;
+let knownUserCount = 0;
+let lastUsersIndexWrite = 0;
+
+// Hot/cold storage split constants and state
+const COLD_PREFIX = 'snapshots_';
+const COLD_DEBOUNCE_MS = 8000;
+const STORAGE_VERSION_KEY = 'metricsStorageVersion';
+const CURRENT_STORAGE_VERSION = 2;
+const coldSnapshotBuffer = new Map(); // Map<userKey, Map<postId, snapshot[]>>
+const coldDirtyUsers = new Set();
+let coldWriteTimer = null;
+
+let isFlushing = false;
+let needsFlush = false;
+
+function normalizeMetrics(raw) {
+  if (!raw || typeof raw !== 'object') return { ...DEFAULT_METRICS };
+  const users = raw.users;
+  if (!users || typeof users !== 'object' || Array.isArray(users)) return { ...DEFAULT_METRICS };
+  return { ...raw, users };
+}
+
+function rebuildPostIndex(metrics) {
+  postIdToUserKey.clear();
+  const users = metrics?.users || {};
+  for (const [userKey, user] of Object.entries(users)) {
+    const posts = user?.posts;
+    if (!posts || typeof posts !== 'object') continue;
+    for (const postId of Object.keys(posts)) {
+      postIdToUserKey.set(postId, userKey);
+    }
+  }
+}
+
+function cacheMetrics(rawMetrics, updatedAt, opts) {
+  const normalized = normalizeMetrics(rawMetrics);
+  metricsCache = normalized;
+  metricsCacheUpdatedAt = Number(updatedAt) || 0;
+  if (opts?.rebuildIndex !== false) {
+    rebuildPostIndex(normalized);
+  }
+}
+
+async function loadMetricsFromStorage() {
+  if (metricsCacheLoading) return metricsCacheLoading;
+  metricsCacheLoading = (async () => {
+    try {
+      const stored = await chrome.storage.local.get([METRICS_STORAGE_KEY, METRICS_UPDATED_AT_KEY]);
+      cacheMetrics(stored[METRICS_STORAGE_KEY], stored[METRICS_UPDATED_AT_KEY]);
+    } catch {
+      metricsCache = normalizeMetrics(null);
+      metricsCacheUpdatedAt = metricsCacheUpdatedAt || 0;
+    } finally {
+      metricsCacheLoading = null;
+    }
+    return { metrics: metricsCache || { users: {} }, metricsUpdatedAt: metricsCacheUpdatedAt || 0 };
+  })();
+  return metricsCacheLoading;
+}
+
+async function migrateStorageIfNeeded() {
+  try {
+    const stored = await chrome.storage.local.get([STORAGE_VERSION_KEY, METRICS_STORAGE_KEY]);
+    if (stored[STORAGE_VERSION_KEY] === CURRENT_STORAGE_VERSION) return;
+    const raw = stored[METRICS_STORAGE_KEY];
+    if (!raw || !raw.users) {
+      // No metrics to migrate, just stamp the version
+      await chrome.storage.local.set({ [STORAGE_VERSION_KEY]: CURRENT_STORAGE_VERSION });
+      return;
+    }
+    const coldShards = {};
+    for (const [userKey, user] of Object.entries(raw.users)) {
+      if (!user?.posts) continue;
+      const shardData = {};
+      let hasColdData = false;
+      for (const [postId, post] of Object.entries(user.posts)) {
+        if (!Array.isArray(post.snapshots) || post.snapshots.length <= 1) continue;
+        // Copy full snapshot history to cold shard
+        shardData[postId] = post.snapshots.slice();
+        // Trim hot post to latest snapshot only
+        post.snapshots = [post.snapshots[post.snapshots.length - 1]];
+        hasColdData = true;
+      }
+      if (hasColdData) {
+        coldShards[COLD_PREFIX + userKey] = shardData;
+      }
+    }
+    const writePayload = {
+      [METRICS_STORAGE_KEY]: raw,
+      [STORAGE_VERSION_KEY]: CURRENT_STORAGE_VERSION,
+      ...coldShards
+    };
+    await chrome.storage.local.set(writePayload);
+    dlog('storage', 'migration v2 complete', { coldShards: Object.keys(coldShards).length });
+  } catch (err) {
+    try { console.warn('[SoraMetrics] migration failed', err); } catch {}
+  }
+}
+
+async function getMetricsState() {
+  if (metricsCache) {
+    return { metrics: metricsCache, metricsUpdatedAt: metricsCacheUpdatedAt || 0 };
+  }
+  return loadMetricsFromStorage();
+}
+
+function toTs(v) {
+  if (typeof v === 'number' && isFinite(v)) return v < 1e11 ? v * 1000 : v;
+  if (typeof v === 'string' && v.trim()) {
+    const s = v.trim();
+    if (/^\d+$/.test(s)) {
+      const n = Number(s);
+      return n < 1e11 ? n * 1000 : n;
+    }
+    const d = Date.parse(s);
+    if (!isNaN(d)) return d;
+  }
+  return 0;
+}
+
+function getPostTimeMs(p) {
+  const cands = [p?.post_time, p?.postTime, p?.post?.post_time, p?.post?.postTime, p?.meta?.post_time];
+  for (const c of cands) {
+    const t = toTs(c);
+    if (t) return t;
+  }
+  return 0;
+}
+
+function latestSnapshot(snaps) {
+  if (!Array.isArray(snaps) || snaps.length === 0) return null;
+  const last = snaps[snaps.length - 1];
+  if (last?.t != null) return last;
+  let best = null;
+  let bt = -Infinity;
+  for (const s of snaps) {
+    const t = Number(s?.t);
+    if (isFinite(t) && t > bt) {
+      bt = t;
+      best = s;
+    }
+  }
+  return best || last || null;
+}
+
+function pickSnapshotFields(snap) {
+  if (!snap || typeof snap !== 'object') return null;
+  return {
+    t: snap.t ?? null,
+    uv: snap.uv ?? null,
+    likes: snap.likes ?? null,
+    views: snap.views ?? null,
+    comments: snap.comments ?? null,
+    remixes: snap.remixes ?? null,
+    remix_count: snap.remix_count ?? snap.remixes ?? null,
+    duration: snap.duration ?? null,
+    width: snap.width ?? null,
+    height: snap.height ?? null,
+  };
+}
+
+function trimPostForResponse(post, snapshotMode) {
+  if (!post || typeof post !== 'object') return null;
+  const postTime = getPostTimeMs(post);
+  let snapshots = [];
+  if (snapshotMode === 'all' && Array.isArray(post.snapshots)) {
+    snapshots = post.snapshots.map(pickSnapshotFields).filter(Boolean);
+  } else {
+    const latest = latestSnapshot(post.snapshots);
+    if (latest) {
+      const picked = pickSnapshotFields(latest);
+      if (picked) snapshots = [picked];
+    }
+  }
+  return {
+    url: post.url ?? null,
+    thumb: post.thumb ?? null,
+    caption: typeof post.caption === 'string' ? post.caption : null,
+    text: typeof post.text === 'string' ? post.text : null,
+    ownerKey: post.ownerKey ?? null,
+    ownerHandle: post.ownerHandle ?? null,
+    ownerId: post.ownerId ?? null,
+    userHandle: post.userHandle ?? null,
+    userKey: post.userKey ?? null,
+    post_time: postTime || null,
+    duration: post.duration ?? null,
+    width: post.width ?? null,
+    height: post.height ?? null,
+    cameo_usernames: post.cameo_usernames ?? null,
+    snapshots,
+  };
+}
+
+function findPost(metrics, postId) {
+  if (!postId || typeof postId !== 'string') return null;
+  const userKey = postIdToUserKey.get(postId);
+  if (userKey && metrics?.users?.[userKey]?.posts?.[postId]) {
+    return { userKey, post: metrics.users[userKey].posts[postId] };
+  }
+  const users = metrics?.users || {};
+  for (const [uKey, user] of Object.entries(users)) {
+    const posts = user?.posts;
+    if (!posts || typeof posts !== 'object') continue;
+    if (posts[postId]) {
+      postIdToUserKey.set(postId, uKey);
+      return { userKey: uKey, post: posts[postId] };
+    }
+    for (const parentPost of Object.values(posts)) {
+      const remixPostsData = parentPost?.remix_posts;
+      const remixPosts = Array.isArray(remixPostsData)
+        ? remixPostsData
+        : (Array.isArray(remixPostsData?.items) ? remixPostsData.items : []);
+      for (const remixItem of remixPosts) {
+        const remixPost = remixItem?.post || remixItem;
+        const remixId = remixPost?.id || remixPost?.post_id;
+        if (remixId === postId) {
+          postIdToUserKey.set(postId, uKey);
+          return { userKey: uKey, post: remixPost };
+        }
+      }
+    }
+  }
+  return null;
+}
+
+function buildAnalyzeMetrics(metrics, windowHours) {
+  const trimmed = { users: {} };
+  const NOW = Date.now();
+  const hours = Math.min(24, Math.max(1, Number(windowHours) || 24));
+  const windowMs = hours * 60 * 60 * 1000;
+  const users = metrics?.users || {};
+  for (const [userKey, user] of Object.entries(users)) {
+    const posts = user?.posts;
+    if (!posts || typeof posts !== 'object') continue;
+    const nextPosts = {};
+    for (const [pid, p] of Object.entries(posts)) {
+      const tPost = getPostTimeMs(p);
+      if (!tPost || NOW - tPost > windowMs) continue;
+      const latest = latestSnapshot(p?.snapshots);
+      if (!latest) continue;
+      const trimmedPost = trimPostForResponse(p, 'latest');
+      if (!trimmedPost) continue;
+      nextPosts[pid] = trimmedPost;
+    }
+    if (Object.keys(nextPosts).length) {
+      trimmed.users[userKey] = {
+        handle: user?.handle ?? user?.userHandle ?? null,
+        userHandle: user?.userHandle ?? user?.handle ?? null,
+        id: user?.id ?? user?.userId ?? null,
+        posts: nextPosts,
+      };
+    }
+  }
+  return trimmed;
+}
+
+function buildPostMetrics(metrics, postId, snapshotMode) {
+  const result = { users: {} };
+  const found = findPost(metrics, postId);
+  if (!found) return result;
+  const { userKey, post } = found;
+  const user = metrics?.users?.[userKey] || {};
+  const trimmedPost = trimPostForResponse(post, snapshotMode);
+  if (!trimmedPost) return result;
+  result.users[userKey] = {
+    handle: user?.handle ?? user?.userHandle ?? null,
+    userHandle: user?.userHandle ?? user?.handle ?? null,
+    id: user?.id ?? user?.userId ?? null,
+    posts: { [postId]: trimmedPost },
+  };
+  return result;
+}
+
+function buildMetricsForRequest(metrics, req) {
+  const scope = typeof req?.scope === 'string' ? req.scope.toLowerCase() : 'full';
+  if (scope === 'analyze') {
+    return buildAnalyzeMetrics(metrics, req?.windowHours);
+  }
+  if (scope === 'post') {
+    const snapshotMode = req?.snapshotMode === 'all' ? 'all' : 'latest';
+    return buildPostMetrics(metrics, req?.postId, snapshotMode);
+  }
+  return metrics;
+}
+
+function scheduleFlush() {
+  if (flushTimer) return;
+  flushTimer = setTimeout(flush, 750);
+}
+
+function scheduleColdWrite() {
+  if (coldWriteTimer) return;
+  coldWriteTimer = setTimeout(flushCold, COLD_DEBOUNCE_MS);
+}
+
+async function flush() {
+  flushTimer = null;
+
+  // If already flushing, mark that we need another pass and return
+  if (isFlushing) {
+    needsFlush = true;
+    return;
+  }
+
+  if (!PENDING.length) return;
+
+  isFlushing = true;
+
+  try {
+    // Check purge lock to prevent overwriting dashboard purge
+    try {
+      const { purgeLock } = await chrome.storage.local.get('purgeLock');
+      if (purgeLock && Date.now() - purgeLock < 30000) { // 30s timeout
+         dlog('storage', 'purge locked, retrying', {});
+         isFlushing = false;
+         scheduleFlush();
+         return;
+      }
+    } catch {}
+
+    // Take current items
+    const items = PENDING.splice(0, PENDING.length);
+    try {
+      const { metrics } = await getMetricsState();
+      dlog('storage', 'flush begin', { count: items.length });
+      let dirty = false;
+      for (const snap of items) {
+        const userKey = snap.userKey || snap.pageUserKey || 'unknown';
+        let isNewUser = false;
+        if (!metrics.users[userKey]) {
+          isNewUser = true;
+          dirty = true;
+        }
+        const userEntry = metrics.users[userKey] || (metrics.users[userKey] = { handle: snap.userHandle || snap.pageUserHandle || null, id: snap.userId || null, posts: {}, followers: [], cameos: [] });
+        if (!userEntry.posts || typeof userEntry.posts !== 'object' || Array.isArray(userEntry.posts)) userEntry.posts = {};
+        if (!Array.isArray(userEntry.followers)) userEntry.followers = [];
+        if (snap.postId) {
+          postIdToUserKey.set(snap.postId, userKey);
+          let isNewPost = false;
+          if (!userEntry.posts[snap.postId]) {
+            isNewPost = true;
+            dirty = true;
+          }
+          const post = userEntry.posts[snap.postId] || (userEntry.posts[snap.postId] = { url: snap.url || null, thumb: snap.thumb || null, snapshots: [] });
+          // Persist owner attribution on the post to allow dashboard integrity checks
+          if (!post.ownerKey && (snap.userKey || snap.pageUserKey)) { post.ownerKey = snap.userKey || snap.pageUserKey; dirty = true; }
+          if (!post.ownerHandle && (snap.userHandle || snap.pageUserHandle)) { post.ownerHandle = snap.userHandle || snap.pageUserHandle; dirty = true; }
+          if (!post.ownerId && snap.userId != null) { post.ownerId = snap.userId; dirty = true; }
+          if (!post.url && snap.url) { post.url = snap.url; dirty = true; }
+          // Capture/refresh caption
+          if (typeof snap.caption === 'string' && snap.caption) {
+            if (!post.caption) { post.caption = snap.caption; dirty = true; }
+            else if (post.caption !== snap.caption) { post.caption = snap.caption; dirty = true; }
+          }
+          // Capture/refresh cameo_usernames
+          if (snap.cameo_usernames != null) {
+            if (Array.isArray(snap.cameo_usernames) && snap.cameo_usernames.length > 0) {
+              post.cameo_usernames = snap.cameo_usernames; dirty = true;
+            } else if (!post.cameo_usernames) {
+              // Only set to null/empty if it wasn't already set (preserve existing data)
+              post.cameo_usernames = null;
+            }
+          }
+          // Update thumbnail when a better/different one becomes available
+          if (snap.thumb) {
+            if (!post.thumb) {
+              post.thumb = snap.thumb; dirty = true;
+              dlog('thumbs', 'thumb set', { postId: snap.postId, thumb: post.thumb });
+            } else if (post.thumb !== snap.thumb) {
+              dlog('thumbs', 'thumb update', { postId: snap.postId, old: post.thumb, new: snap.thumb });
+              post.thumb = snap.thumb; dirty = true;
+            } else {
+              dlog('thumbs', 'thumb unchanged', { postId: snap.postId, thumb: post.thumb });
+            }
+          } else {
+            dlog('thumbs', 'thumb missing in snap', { postId: snap.postId });
+          }
+          if (!post.post_time && snap.created_at) { post.post_time = snap.created_at; dirty = true; } // Map creation time so dashboard can sort posts
+          // Relationship fields for deriving direct remix counts across metrics
+          if (snap.parent_post_id != null && post.parent_post_id !== snap.parent_post_id) { post.parent_post_id = snap.parent_post_id; dirty = true; }
+          if (snap.root_post_id != null && post.root_post_id !== snap.root_post_id) { post.root_post_id = snap.root_post_id; dirty = true; }
+
+          // IMPORTANT: Always update duration and dimensions at post level when available
+          if (snap.duration != null) {
+            const d = Number(snap.duration);
+            if (Number.isFinite(d) && post.duration !== d) {
+              const wasSet = post.duration != null;
+              post.duration = d; dirty = true;
+              if (DEBUG.storage) {
+                dlog('storage', wasSet ? 'duration updated' : 'duration set', { postId: snap.postId, duration: d });
+              }
+            }
+          }
+          if (snap.width != null) {
+            const w = Number(snap.width);
+            if (Number.isFinite(w) && post.width !== w) { post.width = w; dirty = true; }
+          }
+          if (snap.height != null) {
+            const h = Number(snap.height);
+            if (Number.isFinite(h) && post.height !== h) { post.height = h; dirty = true; }
+          }
+
+          const s = {
+            t: snap.ts || Date.now(),
+            uv: snap.uv ?? null,
+            likes: snap.likes ?? null,
+            views: snap.views ?? null,
+            comments: snap.comments ?? null,
+            // Store direct remixes; map both names for backward/forward compat
+            remixes: snap.remix_count ?? snap.remixes ?? null,
+            remix_count: snap.remix_count ?? snap.remixes ?? null,
+            // Store duration and dimensions (frame count data)
+            duration: snap.duration ?? null,
+            width: snap.width ?? null,
+            height: snap.height ?? null,
+          };
+
+          // Only add a new snapshot if engagement metrics changed
+          const last = post.snapshots[post.snapshots.length - 1];
+          const same = last && last.uv === s.uv && last.likes === s.likes && last.views === s.views &&
+            last.comments === s.comments && last.remix_count === s.remix_count;
+
+          if (!same) {
+            post.snapshots.push(s);
+            dirty = true;
+            // Buffer for cold write
+            if (!coldSnapshotBuffer.has(userKey)) coldSnapshotBuffer.set(userKey, new Map());
+            const userBuf = coldSnapshotBuffer.get(userKey);
+            if (!userBuf.has(snap.postId)) userBuf.set(snap.postId, []);
+            userBuf.get(snap.postId).push(s);
+            coldDirtyUsers.add(userKey);
+          } else if (last && (last.duration !== s.duration || last.width !== s.width || last.height !== s.height)) {
+            // If metrics are the same but duration/dimensions changed, update the last snapshot
+            last.duration = s.duration;
+            last.width = s.width;
+            last.height = s.height;
+            dirty = true;
+          }
+
+          post.lastSeen = Date.now();
+        }
+
+        // Capture follower history at the user level when available
+        if (snap.followers != null) {
+          const fCount = Number(snap.followers);
+          if (Number.isFinite(fCount)) {
+            const arr = userEntry.followers;
+            const t = snap.ts || Date.now();
+            const lastF = arr[arr.length - 1];
+            if (!lastF || lastF.count !== fCount) {
+              arr.push({ t, count: fCount });
+              dirty = true;
+              try { console.debug('[SoraMetrics] followers persisted', { userKey, count: fCount, t }); } catch {}
+            }
+          }
+        }
+        // Capture cameo count (profile-level) if available
+        if (snap.cameo_count != null) {
+          const cCount = Number(snap.cameo_count);
+          if (Number.isFinite(cCount)) {
+            if (!Array.isArray(userEntry.cameos)) userEntry.cameos = [];
+            const arr = userEntry.cameos;
+            const t = snap.ts || Date.now();
+            const lastC = arr[arr.length - 1];
+            if (!lastC || lastC.count !== cCount) {
+              arr.push({ t, count: cCount });
+              dirty = true;
+              try { console.debug('[SoraMetrics] cameos persisted', { userKey, count: cCount, t }); } catch {}
+            }
+          }
+        }
+      }
+      if (!dirty) {
+        dlog('storage', 'flush skip (no changes)', {});
+        return;
+      }
+      try {
+        // Trim hot metrics to latest-snapshot-only before writing
+        for (const user of Object.values(metrics.users || {})) {
+          for (const post of Object.values(user?.posts || {})) {
+            if (Array.isArray(post.snapshots) && post.snapshots.length > 1) {
+              post.snapshots = [post.snapshots[post.snapshots.length - 1]];
+            }
+          }
+        }
+
+        const metricsUpdatedAt = Date.now();
+        const currentUserCount = Object.keys(metrics.users || {}).length;
+        const shouldWriteIndex = currentUserCount !== knownUserCount || (metricsUpdatedAt - lastUsersIndexWrite >= 30000);
+        const payload = {
+          [METRICS_STORAGE_KEY]: metrics,
+          [METRICS_UPDATED_AT_KEY]: metricsUpdatedAt,
+        };
+        if (shouldWriteIndex) {
+          payload[METRICS_USERS_INDEX_KEY] = Object.entries(metrics.users || {}).map(([key, user])=>({
+            key,
+            handle: user?.handle || null,
+            id: user?.id || null,
+            postCount: Object.keys(user?.posts || {}).length
+          }));
+          knownUserCount = currentUserCount;
+          lastUsersIndexWrite = metricsUpdatedAt;
+        }
+        lastSelfWriteTs = metricsUpdatedAt;
+        await chrome.storage.local.set(payload);
+        metricsCache = metrics;
+        metricsCacheUpdatedAt = metricsUpdatedAt;
+        // Schedule cold shard writes if there are buffered snapshots
+        if (coldDirtyUsers.size > 0) {
+          scheduleColdWrite();
+        }
+        // Debug: Verify duration is in the metrics we just saved
+        if (DEBUG.storage) {
+          const sampleUser = Object.values(metrics.users || {})[0];
+          if (sampleUser && sampleUser.posts) {
+            const postsWithDuration = Object.values(sampleUser.posts).filter(p => p.duration != null);
+            dlog('storage', 'flush end', {
+              totalPosts: Object.values(metrics.users || {}).reduce((sum, u) => sum + Object.keys(u.posts || {}).length, 0),
+              postsWithDuration: postsWithDuration.length
+            });
+          } else {
+            dlog('storage', 'flush end', {});
+          }
+        }
+      } catch (err) {
+        try { console.warn('[SoraMetrics] storage.set failed; enable unlimitedStorage or lower snapshot cap', err); } catch {}
+      }
+    } catch (e) {
+      try { console.warn('[SoraMetrics] flush failed', e); } catch {}
+    }
+  } finally {
+    isFlushing = false;
+    if (needsFlush) {
+      needsFlush = false;
+      scheduleFlush();
+    }
+  }
+}
+
+async function flushCold() {
+  coldWriteTimer = null;
+  if (coldDirtyUsers.size === 0) return;
+  // Check purge lock to prevent overwriting dashboard purge
+  try {
+    const { purgeLock } = await chrome.storage.local.get('purgeLock');
+    if (purgeLock && Date.now() - purgeLock < 30000) {
+      // Retry after a delay
+      coldWriteTimer = setTimeout(flushCold, 2000);
+      return;
+    }
+  } catch {}
+
+  const dirtyKeys = Array.from(coldDirtyUsers);
+  coldDirtyUsers.clear();
+
+  try {
+    // Read existing cold shards for dirty users
+    const storageKeys = dirtyKeys.map(k => COLD_PREFIX + k);
+    const existing = await chrome.storage.local.get(storageKeys);
+    const writePayload = {};
+
+    for (const userKey of dirtyKeys) {
+      const shardKey = COLD_PREFIX + userKey;
+      const existingShard = existing[shardKey] || {};
+      const buffered = coldSnapshotBuffer.get(userKey);
+      if (!buffered) continue;
+
+      for (const [postId, newSnaps] of buffered.entries()) {
+        if (!existingShard[postId]) {
+          existingShard[postId] = [];
+        }
+        // Append buffered snapshots (dedup by timestamp)
+        const existingTs = new Set(existingShard[postId].map(s => s.t));
+        for (const s of newSnaps) {
+          if (!existingTs.has(s.t)) {
+            existingShard[postId].push(s);
+          }
+        }
+      }
+      writePayload[shardKey] = existingShard;
+      coldSnapshotBuffer.delete(userKey);
+    }
+
+    if (Object.keys(writePayload).length > 0) {
+      await chrome.storage.local.set(writePayload);
+      dlog('storage', 'cold flush complete', { shards: Object.keys(writePayload).length });
+    }
+  } catch (err) {
+    // Re-mark as dirty so we retry
+    for (const k of dirtyKeys) {
+      if (coldSnapshotBuffer.has(k)) coldDirtyUsers.add(k);
+    }
+    try { console.warn('[SoraMetrics] cold flush failed', err); } catch {}
+  }
+}
+
+/* ─── Message handlers ─── */
+
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === 'open_dashboard') {
     const url = chrome.runtime.getURL('dashboard.html');
@@ -13,5 +628,65 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     });
     return true; // Keep message channel open for async response
   }
+
+  if (message.action === 'metrics_batch') {
+    const items = message.items;
+    if (Array.isArray(items)) {
+      for (const it of items) PENDING.push(it);
+      scheduleFlush();
+    }
+    return false; // fire-and-forget
+  }
+
+  if (message.action === 'metrics_request') {
+    (async () => {
+      try {
+        const { metrics } = await getMetricsState();
+        const responseMetrics = buildMetricsForRequest(metrics, message);
+        sendResponse({ metrics: responseMetrics, metricsUpdatedAt: metricsCacheUpdatedAt });
+      } catch {
+        sendResponse({ metrics: { users: {} }, metricsUpdatedAt: 0 });
+      }
+    })();
+    return true; // async response
+  }
 });
 
+/* ─── Storage change listener (catches external writes like dashboard purge) ─── */
+
+chrome.storage.onChanged.addListener((changes, areaName) => {
+  if (areaName !== 'local' || !changes) return;
+  // Broadcast ultra mode changes to all Sora content scripts so they never need
+  // their own chrome.storage.onChanged listener (which would deserialize the full
+  // metrics blob into every tab on every flush).
+  if (Object.prototype.hasOwnProperty.call(changes, 'SCT_ULTRA_MODE_V1')) {
+    chrome.tabs.query({ url: 'https://sora.chatgpt.com/*' }, (tabs) => {
+      if (!tabs) return;
+      for (const tab of tabs) {
+        try { chrome.tabs.sendMessage(tab.id, { action: 'ultra_mode_changed' }); } catch {}
+      }
+    });
+  }
+  const hasMetrics = Object.prototype.hasOwnProperty.call(changes, METRICS_STORAGE_KEY);
+  const hasUpdatedAt = Object.prototype.hasOwnProperty.call(changes, METRICS_UPDATED_AT_KEY);
+  // Skip self-triggered writes — we already updated the cache in flush()
+  if (hasUpdatedAt) {
+    const incomingTs = Number(changes[METRICS_UPDATED_AT_KEY]?.newValue) || 0;
+    if (lastSelfWriteTs && Math.abs(incomingTs - lastSelfWriteTs) < 100) {
+      return;
+    }
+  }
+  if (hasMetrics) {
+    const nextMetrics = changes[METRICS_STORAGE_KEY]?.newValue;
+    const nextUpdatedAt = hasUpdatedAt ? changes[METRICS_UPDATED_AT_KEY]?.newValue : metricsCacheUpdatedAt;
+    cacheMetrics(nextMetrics, nextUpdatedAt);
+  } else if (hasUpdatedAt) {
+    const nextUpdatedAt = Number(changes[METRICS_UPDATED_AT_KEY]?.newValue) || 0;
+    metricsCacheUpdatedAt = nextUpdatedAt || metricsCacheUpdatedAt;
+  }
+});
+
+/* ─── Startup ─── */
+
+// Run one-time migration from v1 (monolithic) to v2 (hot/cold split)
+migrateStorageIfNeeded();

--- a/content.js
+++ b/content.js
@@ -7,8 +7,6 @@
   const p = String(location.pathname || '');
   const isDraftDetail = p === '/d' || p.startsWith('/d/');
   const ULTRA_MODE_KEY = 'SCT_ULTRA_MODE_V1';
-  const METRICS_USERS_INDEX_KEY = 'metricsUsersIndex';
-
   function writeUltraModeToLocalStorage(enabled) {
     try {
       localStorage.setItem(ULTRA_MODE_KEY, JSON.stringify({ enabled: !!enabled, setAt: Date.now() }));
@@ -27,11 +25,11 @@
   }
 
   syncUltraModePreference();
+  // Listen for ultra mode changes broadcast from background (avoids chrome.storage.onChanged
+  // which would serialize the full metrics blob to every content script on every flush).
   try {
-    chrome.storage.onChanged.addListener((changes, areaName) => {
-      if (areaName !== 'local') return;
-      if (!changes || !Object.prototype.hasOwnProperty.call(changes, ULTRA_MODE_KEY)) return;
-      syncUltraModePreference();
+    chrome.runtime.onMessage.addListener((message) => {
+      if (message?.action === 'ultra_mode_changed') syncUltraModePreference();
     });
   } catch {}
 
@@ -130,508 +128,38 @@
 
   if (isDraftDetail) return;
 
-  // Listen for metrics snapshots posted from the injected script and persist to storage.
-  (function () {
-  const PENDING = [];
-  let flushTimer = null;
-  const metricsFallback = { users: {} };
-  const METRICS_STORAGE_KEY = 'metrics';
-  const METRICS_UPDATED_AT_KEY = 'metricsUpdatedAt';
-
-  // Debug toggles
-  const DEBUG = { storage: false, thumbs: false };
-  const dlog = (topic, ...args) => { try { if (DEBUG[topic]) console.log('[SoraUV]', topic, ...args); } catch {} };
-
-  const DEFAULT_METRICS = { users: {} };
-  const postIdToUserKey = new Map();
-  let metricsCache = null;
-  let metricsCacheUpdatedAt = 0;
-  let metricsCacheLoading = null;
-
-  function normalizeMetrics(raw) {
-    if (!raw || typeof raw !== 'object') return { ...DEFAULT_METRICS };
-    const users = raw.users;
-    if (!users || typeof users !== 'object' || Array.isArray(users)) return { ...DEFAULT_METRICS };
-    return { ...raw, users };
-  }
-
-  function rebuildPostIndex(metrics) {
-    postIdToUserKey.clear();
-    const users = metrics?.users || {};
-    for (const [userKey, user] of Object.entries(users)) {
-      const posts = user?.posts;
-      if (!posts || typeof posts !== 'object') continue;
-      for (const postId of Object.keys(posts)) {
-        postIdToUserKey.set(postId, userKey);
-      }
-    }
-  }
-
-  function cacheMetrics(rawMetrics, updatedAt) {
-    const normalized = normalizeMetrics(rawMetrics);
-    metricsCache = normalized;
-    metricsCacheUpdatedAt = Number(updatedAt) || 0;
-    rebuildPostIndex(normalized);
-  }
-
-  async function loadMetricsFromStorage() {
-    if (metricsCacheLoading) return metricsCacheLoading;
-    metricsCacheLoading = (async () => {
-      try {
-        const stored = await chrome.storage.local.get([METRICS_STORAGE_KEY, METRICS_UPDATED_AT_KEY]);
-        cacheMetrics(stored[METRICS_STORAGE_KEY], stored[METRICS_UPDATED_AT_KEY]);
-      } catch {
-        metricsCache = normalizeMetrics(null);
-        metricsCacheUpdatedAt = metricsCacheUpdatedAt || 0;
-      } finally {
-        metricsCacheLoading = null;
-      }
-      return { metrics: metricsCache || { users: {} }, metricsUpdatedAt: metricsCacheUpdatedAt || 0 };
-    })();
-    return metricsCacheLoading;
-  }
-
-  async function getMetricsState() {
-    if (metricsCache) {
-      return { metrics: metricsCache, metricsUpdatedAt: metricsCacheUpdatedAt || 0 };
-    }
-    return loadMetricsFromStorage();
-  }
-
-  function toTs(v) {
-    if (typeof v === 'number' && isFinite(v)) return v < 1e11 ? v * 1000 : v;
-    if (typeof v === 'string' && v.trim()) {
-      const s = v.trim();
-      if (/^\d+$/.test(s)) {
-        const n = Number(s);
-        return n < 1e11 ? n * 1000 : n;
-      }
-      const d = Date.parse(s);
-      if (!isNaN(d)) return d;
-    }
-    return 0;
-  }
-
-  function getPostTimeMs(p) {
-    const cands = [p?.post_time, p?.postTime, p?.post?.post_time, p?.post?.postTime, p?.meta?.post_time];
-    for (const c of cands) {
-      const t = toTs(c);
-      if (t) return t;
-    }
-    return 0;
-  }
-
-  function latestSnapshot(snaps) {
-    if (!Array.isArray(snaps) || snaps.length === 0) return null;
-    const last = snaps[snaps.length - 1];
-    if (last?.t != null) return last;
-    let best = null;
-    let bt = -Infinity;
-    for (const s of snaps) {
-      const t = Number(s?.t);
-      if (isFinite(t) && t > bt) {
-        bt = t;
-        best = s;
-      }
-    }
-    return best || last || null;
-  }
-
-  function pickSnapshotFields(snap) {
-    if (!snap || typeof snap !== 'object') return null;
-    return {
-      t: snap.t ?? null,
-      uv: snap.uv ?? null,
-      likes: snap.likes ?? null,
-      views: snap.views ?? null,
-      comments: snap.comments ?? null,
-      remixes: snap.remixes ?? null,
-      remix_count: snap.remix_count ?? snap.remixes ?? null,
-      duration: snap.duration ?? null,
-      width: snap.width ?? null,
-      height: snap.height ?? null,
-    };
-  }
-
-  function trimPostForResponse(post, snapshotMode) {
-    if (!post || typeof post !== 'object') return null;
-    const postTime = getPostTimeMs(post);
-    let snapshots = [];
-    if (snapshotMode === 'all' && Array.isArray(post.snapshots)) {
-      snapshots = post.snapshots.map(pickSnapshotFields).filter(Boolean);
-    } else {
-      const latest = latestSnapshot(post.snapshots);
-      if (latest) {
-        const picked = pickSnapshotFields(latest);
-        if (picked) snapshots = [picked];
-      }
-    }
-    return {
-      url: post.url ?? null,
-      thumb: post.thumb ?? null,
-      caption: typeof post.caption === 'string' ? post.caption : null,
-      text: typeof post.text === 'string' ? post.text : null,
-      ownerKey: post.ownerKey ?? null,
-      ownerHandle: post.ownerHandle ?? null,
-      ownerId: post.ownerId ?? null,
-      userHandle: post.userHandle ?? null,
-      userKey: post.userKey ?? null,
-      post_time: postTime || null,
-      duration: post.duration ?? null,
-      width: post.width ?? null,
-      height: post.height ?? null,
-      cameo_usernames: post.cameo_usernames ?? null,
-      snapshots,
-    };
-  }
-
-  function findPost(metrics, postId) {
-    if (!postId || typeof postId !== 'string') return null;
-    const userKey = postIdToUserKey.get(postId);
-    if (userKey && metrics?.users?.[userKey]?.posts?.[postId]) {
-      return { userKey, post: metrics.users[userKey].posts[postId] };
-    }
-    const users = metrics?.users || {};
-    for (const [uKey, user] of Object.entries(users)) {
-      const posts = user?.posts;
-      if (!posts || typeof posts !== 'object') continue;
-      if (posts[postId]) {
-        postIdToUserKey.set(postId, uKey);
-        return { userKey: uKey, post: posts[postId] };
-      }
-      for (const parentPost of Object.values(posts)) {
-        const remixPostsData = parentPost?.remix_posts;
-        const remixPosts = Array.isArray(remixPostsData)
-          ? remixPostsData
-          : (Array.isArray(remixPostsData?.items) ? remixPostsData.items : []);
-        for (const remixItem of remixPosts) {
-          const remixPost = remixItem?.post || remixItem;
-          const remixId = remixPost?.id || remixPost?.post_id;
-          if (remixId === postId) {
-            postIdToUserKey.set(postId, uKey);
-            return { userKey: uKey, post: remixPost };
-          }
-        }
-      }
-    }
-    return null;
-  }
-
-  function buildAnalyzeMetrics(metrics, windowHours) {
-    const trimmed = { users: {} };
-    const NOW = Date.now();
-    const hours = Math.min(24, Math.max(1, Number(windowHours) || 24));
-    const windowMs = hours * 60 * 60 * 1000;
-    const users = metrics?.users || {};
-    for (const [userKey, user] of Object.entries(users)) {
-      const posts = user?.posts;
-      if (!posts || typeof posts !== 'object') continue;
-      const nextPosts = {};
-      for (const [pid, p] of Object.entries(posts)) {
-        const tPost = getPostTimeMs(p);
-        if (!tPost || NOW - tPost > windowMs) continue;
-        const latest = latestSnapshot(p?.snapshots);
-        if (!latest) continue;
-        const trimmedPost = trimPostForResponse(p, 'latest');
-        if (!trimmedPost) continue;
-        nextPosts[pid] = trimmedPost;
-      }
-      if (Object.keys(nextPosts).length) {
-        trimmed.users[userKey] = {
-          handle: user?.handle ?? user?.userHandle ?? null,
-          userHandle: user?.userHandle ?? user?.handle ?? null,
-          id: user?.id ?? user?.userId ?? null,
-          posts: nextPosts,
-        };
-      }
-    }
-    return trimmed;
-  }
-
-  function buildPostMetrics(metrics, postId, snapshotMode) {
-    const result = { users: {} };
-    const found = findPost(metrics, postId);
-    if (!found) return result;
-    const { userKey, post } = found;
-    const user = metrics?.users?.[userKey] || {};
-    const trimmedPost = trimPostForResponse(post, snapshotMode);
-    if (!trimmedPost) return result;
-    result.users[userKey] = {
-      handle: user?.handle ?? user?.userHandle ?? null,
-      userHandle: user?.userHandle ?? user?.handle ?? null,
-      id: user?.id ?? user?.userId ?? null,
-      posts: { [postId]: trimmedPost },
-    };
-    return result;
-  }
-
-  function buildMetricsForRequest(metrics, req) {
-    const scope = typeof req?.scope === 'string' ? req.scope.toLowerCase() : 'full';
-    if (scope === 'analyze') {
-      return buildAnalyzeMetrics(metrics, req?.windowHours);
-    }
-    if (scope === 'post') {
-      const snapshotMode = req?.snapshotMode === 'all' ? 'all' : 'latest';
-      return buildPostMetrics(metrics, req?.postId, snapshotMode);
-    }
-    return metrics;
-  }
-
-  function scheduleFlush() {
-    if (flushTimer) return;
-    flushTimer = setTimeout(flush, 750);
-  }
-
-  function onMessage(ev) {
+  // Relay metrics batches from inject.js to background service worker (fire-and-forget).
+  window.addEventListener('message', function(ev) {
     if (ev?.source !== window) return;
     const d = ev?.data;
     if (!d || d.__sora_uv__ !== true || d.type !== 'metrics_batch' || !Array.isArray(d.items)) return;
-    for (const it of d.items) PENDING.push(it);
-    scheduleFlush();
-  }
-
-  (function(){
-    function onMetricsRequest(ev){
-      const d = ev?.data;
-      if (!d || d.__sora_uv__ !== true || d.type !== 'metrics_request') return;
-      const req = d.req;
-      (async () => {
-        try {
-          const { metrics, metricsUpdatedAt } = await getMetricsState();
-          const responseMetrics = buildMetricsForRequest(metrics, d);
-          // Reply back into the page
-          window.postMessage({ __sora_uv__: true, type: 'metrics_response', req, metrics: responseMetrics, metricsUpdatedAt }, '*');
-        } catch {
-          // Fall back to an empty payload if storage is unavailable
-          window.postMessage({ __sora_uv__: true, type: 'metrics_response', req, metrics: metricsFallback, metricsUpdatedAt: 0 }, '*');
-        }
-      })();
-    }
-    window.addEventListener('message', onMetricsRequest);
-  })();
-
-  try {
-    chrome.storage.onChanged.addListener((changes, areaName) => {
-      if (areaName !== 'local' || !changes) return;
-      const hasMetrics = Object.prototype.hasOwnProperty.call(changes, METRICS_STORAGE_KEY);
-      const hasUpdatedAt = Object.prototype.hasOwnProperty.call(changes, METRICS_UPDATED_AT_KEY);
-      if (hasMetrics) {
-        const nextMetrics = changes[METRICS_STORAGE_KEY]?.newValue;
-        const nextUpdatedAt = hasUpdatedAt ? changes[METRICS_UPDATED_AT_KEY]?.newValue : metricsCacheUpdatedAt;
-        cacheMetrics(nextMetrics, nextUpdatedAt);
-      } else if (hasUpdatedAt) {
-        const nextUpdatedAt = Number(changes[METRICS_UPDATED_AT_KEY]?.newValue) || 0;
-        metricsCacheUpdatedAt = nextUpdatedAt || metricsCacheUpdatedAt;
-      }
-    });
-  } catch {}
-
-  let isFlushing = false;
-  let needsFlush = false;
-
-  async function flush() {
-    flushTimer = null;
-    
-    // If already flushing, mark that we need another pass and return
-    if (isFlushing) {
-      needsFlush = true;
-      return;
-    }
-    
-    if (!PENDING.length) return;
-    
-    isFlushing = true;
-
     try {
-      // Check purge lock to prevent overwriting dashboard purge
-      try {
-        const { purgeLock } = await chrome.storage.local.get('purgeLock');
-        if (purgeLock && Date.now() - purgeLock < 30000) { // 30s timeout
-           dlog('storage', 'purge locked, retrying', {});
-           isFlushing = false;
-           scheduleFlush();
-           return;
-        }
-      } catch {}
-  
-      // Take current items
-      const items = PENDING.splice(0, PENDING.length);
-      try {
-        const { metrics } = await getMetricsState();
-        dlog('storage', 'flush begin', { count: items.length });
-        for (const snap of items) {
-          const userKey = snap.userKey || snap.pageUserKey || 'unknown';
-          const userEntry = metrics.users[userKey] || (metrics.users[userKey] = { handle: snap.userHandle || snap.pageUserHandle || null, id: snap.userId || null, posts: {}, followers: [], cameos: [] });
-          if (!userEntry.posts || typeof userEntry.posts !== 'object' || Array.isArray(userEntry.posts)) userEntry.posts = {};
-          if (!Array.isArray(userEntry.followers)) userEntry.followers = [];
-          if (snap.postId) {
-            postIdToUserKey.set(snap.postId, userKey);
-            const post = userEntry.posts[snap.postId] || (userEntry.posts[snap.postId] = { url: snap.url || null, thumb: snap.thumb || null, snapshots: [] });
-            // Persist owner attribution on the post to allow dashboard integrity checks
-            if (!post.ownerKey && (snap.userKey || snap.pageUserKey)) post.ownerKey = snap.userKey || snap.pageUserKey;
-            if (!post.ownerHandle && (snap.userHandle || snap.pageUserHandle)) post.ownerHandle = snap.userHandle || snap.pageUserHandle;
-            if (!post.ownerId && snap.userId != null) post.ownerId = snap.userId;
-            if (!post.url && snap.url) post.url = snap.url;
-            // Capture/refresh caption
-            if (typeof snap.caption === 'string' && snap.caption) {
-              if (!post.caption) post.caption = snap.caption;
-              else if (post.caption !== snap.caption) post.caption = snap.caption;
-            }
-            // Capture/refresh cameo_usernames
-            if (snap.cameo_usernames != null) {
-              if (Array.isArray(snap.cameo_usernames) && snap.cameo_usernames.length > 0) {
-                post.cameo_usernames = snap.cameo_usernames;
-              } else if (!post.cameo_usernames) {
-                // Only set to null/empty if it wasn't already set (preserve existing data)
-                post.cameo_usernames = null;
-              }
-            }
-            // Update thumbnail when a better/different one becomes available
-            if (snap.thumb) {
-              if (!post.thumb) {
-                post.thumb = snap.thumb;
-                dlog('thumbs', 'thumb set', { postId: snap.postId, thumb: post.thumb });
-              } else if (post.thumb !== snap.thumb) {
-                dlog('thumbs', 'thumb update', { postId: snap.postId, old: post.thumb, new: snap.thumb });
-                post.thumb = snap.thumb;
-              } else {
-                dlog('thumbs', 'thumb unchanged', { postId: snap.postId, thumb: post.thumb });
-              }
-            } else {
-              dlog('thumbs', 'thumb missing in snap', { postId: snap.postId });
-            }
-            if (!post.post_time && snap.created_at) post.post_time = snap.created_at; // Map creation time so dashboard can sort posts
-            // Relationship fields for deriving direct remix counts across metrics
-            if (snap.parent_post_id != null) post.parent_post_id = snap.parent_post_id;
-            if (snap.root_post_id != null) post.root_post_id = snap.root_post_id;
-            
-            // IMPORTANT: Always update duration and dimensions at post level when available
-            // This ensures we capture frame count data even if metrics haven't changed
-            // (duration doesn't affect snapshot deduplication since we check it separately below)
-            if (snap.duration != null) {
-              const d = Number(snap.duration);
-              if (Number.isFinite(d)) {
-                const wasSet = post.duration != null;
-                post.duration = d;
-                if (DEBUG.storage) {
-                  dlog('storage', wasSet ? 'duration updated' : 'duration set', { postId: snap.postId, duration: d });
-                }
-              }
-            }
-            if (snap.width != null) {
-              const w = Number(snap.width);
-              if (Number.isFinite(w)) post.width = w;
-            }
-            if (snap.height != null) {
-              const h = Number(snap.height);
-              if (Number.isFinite(h)) post.height = h;
-            }
-  
-            const s = {
-              t: snap.ts || Date.now(),
-              uv: snap.uv ?? null,
-              likes: snap.likes ?? null,
-              views: snap.views ?? null,
-              comments: snap.comments ?? null,
-              // Store direct remixes; map both names for backward/forward compat
-              remixes: snap.remix_count ?? snap.remixes ?? null,
-              remix_count: snap.remix_count ?? snap.remixes ?? null,
-              // Store duration and dimensions (frame count data)
-              duration: snap.duration ?? null,
-              width: snap.width ?? null,
-              height: snap.height ?? null,
-              // shares/downloads removed
-            };
-            
-            // Only add a new snapshot if engagement metrics changed (don't create new snapshot just for duration)
-            const last = post.snapshots[post.snapshots.length - 1];
-            const same = last && last.uv === s.uv && last.likes === s.likes && last.views === s.views &&
-              last.comments === s.comments && last.remix_count === s.remix_count;
-            
-            if (!same) {
-              post.snapshots.push(s);
-            } else if (last && (last.duration !== s.duration || last.width !== s.width || last.height !== s.height)) {
-              // If metrics are the same but duration/dimensions changed, update the last snapshot
-              // This handles backfilling duration for existing posts without creating duplicate snapshots
-              last.duration = s.duration;
-              last.width = s.width;
-              last.height = s.height;
-            }
-            
-            post.lastSeen = Date.now();
-          }
-  
-          // Capture follower history at the user level when available
-          if (snap.followers != null) {
-            const fCount = Number(snap.followers);
-            if (Number.isFinite(fCount)) {
-              const arr = userEntry.followers;
-              const t = snap.ts || Date.now();
-              const lastF = arr[arr.length - 1];
-              if (!lastF || lastF.count !== fCount) {
-                arr.push({ t, count: fCount });
-                try { console.debug('[SoraMetrics] followers persisted', { userKey, count: fCount, t }); } catch {}
-              }
-            }
-          }
-          // Capture cameo count (profile-level) if available
-          if (snap.cameo_count != null) {
-            const cCount = Number(snap.cameo_count);
-            if (Number.isFinite(cCount)) {
-              if (!Array.isArray(userEntry.cameos)) userEntry.cameos = [];
-              const arr = userEntry.cameos;
-              const t = snap.ts || Date.now();
-              const lastC = arr[arr.length - 1];
-              if (!lastC || lastC.count !== cCount) {
-                arr.push({ t, count: cCount });
-                try { console.debug('[SoraMetrics] cameos persisted', { userKey, count: cCount, t }); } catch {}
-              }
-            }
-          }
-        }
-        try {
-          const metricsUpdatedAt = Date.now();
-          const usersIndex = Object.entries(metrics.users || {}).map(([key, user])=>({
-            key,
-            handle: user?.handle || null,
-            id: user?.id || null,
-            postCount: Object.keys(user?.posts || {}).length
-          }));
-          await chrome.storage.local.set({
-            [METRICS_STORAGE_KEY]: metrics,
-            [METRICS_UPDATED_AT_KEY]: metricsUpdatedAt,
-            [METRICS_USERS_INDEX_KEY]: usersIndex
-          });
-          metricsCache = metrics;
-          metricsCacheUpdatedAt = metricsUpdatedAt;
-          // Debug: Verify duration is in the metrics we just saved
-          if (DEBUG.storage) {
-            const sampleUser = Object.values(metrics.users || {})[0];
-            if (sampleUser && sampleUser.posts) {
-              const postsWithDuration = Object.values(sampleUser.posts).filter(p => p.duration != null);
-              dlog('storage', 'flush end', { 
-                totalPosts: Object.values(metrics.users || {}).reduce((sum, u) => sum + Object.keys(u.posts || {}).length, 0),
-                postsWithDuration: postsWithDuration.length 
-              });
-            } else {
-              dlog('storage', 'flush end', {});
-            }
-          }
-        } catch (err) {
-          try { console.warn('[SoraMetrics] storage.set failed; enable unlimitedStorage or lower snapshot cap', err); } catch {}
-        }
-      } catch (e) {
-        try { console.warn('[SoraMetrics] flush failed', e); } catch {}
-      }
-    } finally {
-      isFlushing = false;
-      if (needsFlush) {
-        needsFlush = false;
-        scheduleFlush();
-      }
-    }
-  }
+      chrome.runtime.sendMessage({ action: 'metrics_batch', items: d.items });
+    } catch {}
+  });
 
-    window.addEventListener('message', onMessage);
-  })();
+  // Relay metrics requests from inject.js to background and return the response.
+  window.addEventListener('message', function(ev) {
+    if (ev?.source !== window) return;
+    const d = ev?.data;
+    if (!d || d.__sora_uv__ !== true || d.type !== 'metrics_request') return;
+    const req = d.req;
+    try {
+      chrome.runtime.sendMessage({
+        action: 'metrics_request',
+        scope: d.scope,
+        postId: d.postId,
+        windowHours: d.windowHours,
+        snapshotMode: d.snapshotMode,
+      }, (response) => {
+        if (chrome.runtime.lastError || !response) {
+          window.postMessage({ __sora_uv__: true, type: 'metrics_response', req, metrics: { users: {} }, metricsUpdatedAt: 0 }, '*');
+          return;
+        }
+        window.postMessage({ __sora_uv__: true, type: 'metrics_response', req, metrics: response.metrics, metricsUpdatedAt: response.metricsUpdatedAt }, '*');
+      });
+    } catch {
+      window.postMessage({ __sora_uv__: true, type: 'metrics_response', req, metrics: { users: {} }, metricsUpdatedAt: 0 }, '*');
+    }
+  });
 })();


### PR DESCRIPTION
## Summary

  - Move the entire metrics module (~700 lines) from content.js to background.js so a single cache and single writer
   owns chrome.storage, eliminating N×N onChanged broadcasts and per-tab blob deserialization when many Sora tabs
  are open
  - Replace content.js chrome.storage.onChanged listener with a targeted chrome.runtime.onMessage broadcast for
  ultra mode, preventing Chrome from serializing the full metrics blob to every content script on each flush
  - Content scripts shrink from ~828 to ~165 lines, becoming thin message relays to the background service worker
  - Eliminate all getComputedStyle() calls from the card selection pipeline, replacing them with Tailwind class and
  inline style checks — removes thousands of synchronous reflows on pages with many posts
  - Cache DOM query results (selectAllCards(), media element queries) to avoid redundant full-document traversals
  each render pass
  - Add a badge data generation counter so observer-triggered re-renders skip already-processed cards in O(1)
  - Throttle the feed button MutationObserver and suppress cascading render passes during processFeedJson()

## Test plan

  - Open 9+ post pages — should not cause noticeable lag or rainbow wheel
  - Load a profile with many posts — should feel noticeably snappier, badges render quickly
  - Scroll to load more posts — new badges should appear without lag
  - Verify badge accuracy — badges show correct metrics, filters work
  - Dashboard loads and displays all data correctly, purge works
  - Open a post detail page — detail badge renders correctly
  - Check Explore/Drafts pages — filters, badges, bookmark buttons all work
  - Reload extension with tabs open — orphaned tabs degrade gracefully
  - DevTools Performance tab on a content script — confirm zero chrome.storage calls for metrics