### PR TITLE
feat: add discovery phrase support across content and dashboard

### DIFF
--- a/background.js
+++ b/background.js
@@ -123,6 +123,8 @@ function sanitizeMetricsSnapshot(raw) {
   if (thumb) snap.thumb = thumb;
   const caption = sanitizeString(raw.caption, 4096);
   if (caption) snap.caption = caption;
+  const discoveryPhrase = sanitizeString(raw.discovery_phrase, 4096);
+  if (discoveryPhrase) snap.discovery_phrase = discoveryPhrase;
 
   const cameoUsernames = sanitizeCameoUsernames(raw.cameo_usernames);
   if (cameoUsernames) snap.cameo_usernames = cameoUsernames;
@@ -376,6 +378,7 @@ function trimPostForResponse(post, snapshotMode) {
     url: post.url ?? null,
     thumb: post.thumb ?? null,
     caption: typeof post.caption === 'string' ? post.caption : null,
+    discovery_phrase: typeof post.discovery_phrase === 'string' ? post.discovery_phrase : null,
     text: typeof post.text === 'string' ? post.text : null,
     ownerKey: post.ownerKey ?? null,
     ownerHandle: post.ownerHandle ?? null,
@@ -549,6 +552,11 @@ async function flush() {
           if (typeof snap.caption === 'string' && snap.caption) {
             if (!post.caption) { post.caption = snap.caption; dirty = true; }
             else if (post.caption !== snap.caption) { post.caption = snap.caption; dirty = true; }
+          }
+          // Capture/refresh discovery phrase
+          if (typeof snap.discovery_phrase === 'string' && snap.discovery_phrase) {
+            if (!post.discovery_phrase) { post.discovery_phrase = snap.discovery_phrase; dirty = true; }
+            else if (post.discovery_phrase !== snap.discovery_phrase) { post.discovery_phrase = snap.discovery_phrase; dirty = true; }
           }
           // Capture/refresh cameo_usernames
           if (snap.cameo_usernames != null) {

--- a/content.js
+++ b/content.js
@@ -95,6 +95,8 @@
     if (thumb) item.thumb = thumb;
     const caption = sanitizeString(raw.caption, MAX_STR_LEN);
     if (caption) item.caption = caption;
+    const discoveryPhrase = sanitizeString(raw.discovery_phrase, MAX_STR_LEN);
+    if (discoveryPhrase) item.discovery_phrase = discoveryPhrase;
 
     const cameoUsernames = sanitizeCameoUsernames(raw.cameo_usernames);
     if (cameoUsernames) item.cameo_usernames = cameoUsernames;

--- a/dashboard.css
+++ b/dashboard.css
@@ -597,6 +597,13 @@ body.is-purging .sidebar{
 .post .meta .id{font-family:var(--font-mono);font-size:11px;opacity:.8; white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
 .post .meta .id a{color:var(--fg); text-decoration:none; display:block; white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
 .post .meta .id a:hover{color:#fff}
+.post .meta .discovery{
+  font-size:10px;
+  color:rgba(255,255,255,0.72);
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
 .post .thumb{
   width:46px;height:46px;border-radius:10px;
   background:var(--bg-subtle);
@@ -641,6 +648,32 @@ body.is-purging .sidebar{
 }
 
 .post .meta .stats{font-size:11px;color:var(--muted);font-variant-numeric:tabular-nums}
+.sidebar-toggle-row{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  margin:0 0 12px;
+  padding:8px 10px;
+  border:1px solid rgba(255,255,255,0.08);
+  border-radius:12px;
+  background:rgba(var(--panel-soft-rgb),0.34);
+  color:var(--muted);
+  font-size:12px;
+  cursor:pointer;
+  transition:border-color 140ms ease,background 140ms ease,color 140ms ease;
+}
+.sidebar-toggle-row:hover{
+  border-color:rgba(var(--accent-rgb),0.3);
+  background:rgba(var(--panel-soft-rgb),0.5);
+  color:var(--fg);
+}
+.sidebar-toggle-row input{
+  margin:0;
+  accent-color:rgb(var(--accent-rgb));
+}
+.sidebar-toggle-row span{
+  min-width:0;
+}
 .content{
   padding:16px 24px 20px;
   overflow:auto;

--- a/dashboard.html
+++ b/dashboard.html
@@ -73,6 +73,10 @@
           <select id="userSelect" title="All users" class="user-select-dropdown" aria-hidden="true"></select>
         </div>
         <h3>Filter Posts</h3>
+        <label class="sidebar-toggle-row" for="discoveryPhraseToggle">
+          <input type="checkbox" id="discoveryPhraseToggle" />
+          <span>Show discovery phrases</span>
+        </label>
         <div class="list-actions">
           <button id="showAll">Show All</button>
           <button id="hideAll">Hide All</button>

--- a/dashboard.js
+++ b/dashboard.js
@@ -13,6 +13,7 @@
   const AUTO_REFRESH_MAX_NO_CHANGE_SKIPS = 2;
   const CAMEO_KEY_PREFIX = 'c:';
   const ULTRA_MODE_STORAGE_KEY = 'SCT_ULTRA_MODE_V1';
+  const DASHBOARD_DISCOVERY_PHRASE_STORAGE_KEY = 'SCT_DASHBOARD_DISCOVERY_PHRASE_V2';
   const ULTRA_MODE_TAP_COUNT = 5;
   const SITE_ORIGIN = 'https://sora.chatgpt.com';
   const COMPARE_TOTAL_VIEWS_TITLE = 'Total Views over time';
@@ -387,6 +388,7 @@
   let lastSessionCacheAt = 0;
   let currentUserKey = null;
   let lastSelectedUserKey = null;
+  let showDiscoveryPhrase = true;
   let nextAutoRefreshAt = 0;
   let autoRefreshCountdownTimer = null;
   let triggerMetricsAutoRefreshNow = null;
@@ -738,6 +740,9 @@
       if (typeof post.thumb === 'string') out.thumb = post.thumb;
       if (typeof post.caption === 'string') {
         out.caption = post.caption.length > 320 ? post.caption.slice(0, 320) : post.caption;
+      }
+      if (typeof post.discovery_phrase === 'string') {
+        out.discovery_phrase = post.discovery_phrase.length > 320 ? post.discovery_phrase.slice(0, 320) : post.discovery_phrase;
       }
       if (Array.isArray(post.cameos)) out.cameos = post.cameos.slice(0, 12);
       if (post.post_time != null) out.post_time = post.post_time;
@@ -1461,6 +1466,22 @@
   async function saveUltraModePreference(enabled){
     try {
       await chrome.storage.local.set({ [ULTRA_MODE_STORAGE_KEY]: !!enabled });
+    } catch {}
+  }
+
+  async function loadDiscoveryPhrasePreference(){
+    try {
+      const stored = await chrome.storage.local.get(DASHBOARD_DISCOVERY_PHRASE_STORAGE_KEY);
+      if (!Object.prototype.hasOwnProperty.call(stored, DASHBOARD_DISCOVERY_PHRASE_STORAGE_KEY)) return true;
+      return !!stored[DASHBOARD_DISCOVERY_PHRASE_STORAGE_KEY];
+    } catch {
+      return true;
+    }
+  }
+
+  async function saveDiscoveryPhrasePreference(enabled){
+    try {
+      await chrome.storage.local.set({ [DASHBOARD_DISCOVERY_PHRASE_STORAGE_KEY]: !!enabled });
     } catch {}
   }
 
@@ -3183,6 +3204,17 @@
     }
   }
 
+  function normalizeDiscoveryPhrase(value) {
+    if (typeof value !== 'string') return null;
+    const phrase = value.replace(/\s+/g, ' ').trim();
+    return phrase || null;
+  }
+
+  function buildDiscoveryPhraseLine(post) {
+    const phrase = normalizeDiscoveryPhrase(post?.discoveryPhrase ?? post?.discovery_phrase);
+    return phrase || '';
+  }
+
   function truncateForPurgeCaption(text){
     const clean = (typeof text === 'string' ? text.trim() : '') || 'this post';
     if (clean.length <= 100) return clean;
@@ -3480,6 +3512,7 @@
       const rr = rrRaw == null ? null : Number(rrRaw);
       const lastSeen = p?.lastSeen || 0;
       const cap = (typeof p?.caption === 'string' && p.caption) ? p.caption.trim() : null;
+      const discoveryPhrase = normalizeDiscoveryPhrase(p?.discovery_phrase);
       const cameos = Array.isArray(p?.cameo_usernames) ? p.cameo_usernames.filter(c => typeof c === 'string' && c.trim()) : [];
       const owner = isVirtual ? (p?.ownerHandle || '') : (user?.handle || '');
 
@@ -3514,6 +3547,7 @@
         cameos,
         owner,
         caption: cap,
+        discoveryPhrase,
         views,
         likes,
         lastSeen
@@ -3812,6 +3846,13 @@
       const nextStats = `${fmt(p.last?.likes)} Likes - ${fmt1(p.last?.uv)} Viewers - ${p.rate==null?'-':p.rate.toFixed(1)+'%'} IR`;
       if (statsDiv.textContent !== nextStats) statsDiv.textContent = nextStats;
     }
+    const discoveryDiv = cache.discoveryDiv || row.querySelector('.discovery');
+    if (discoveryDiv) {
+      const nextDiscovery = showDiscoveryPhrase ? buildDiscoveryPhraseLine(p) : '';
+      discoveryDiv.textContent = nextDiscovery;
+      discoveryDiv.title = nextDiscovery || '';
+      discoveryDiv.hidden = !nextDiscovery;
+    }
     const toggleDiv = cache.toggleDiv || row.querySelector('.toggle');
     const forceShowAll = !!opts?.forceShowAll;
     if (toggleDiv) {
@@ -3868,8 +3909,15 @@
     statsDiv.className = 'stats';
     statsDiv.textContent = `${fmt(p.last?.likes)} Likes - ${fmt1(p.last?.uv)} Viewers - ${p.rate==null?'-':p.rate.toFixed(1)+'%'} IR`;
 
+    const discoveryDiv = document.createElement('div');
+    discoveryDiv.className = 'discovery';
+    discoveryDiv.textContent = showDiscoveryPhrase ? buildDiscoveryPhraseLine(p) : '';
+    discoveryDiv.title = discoveryDiv.textContent || '';
+    discoveryDiv.hidden = !discoveryDiv.textContent;
+
     metaDiv.appendChild(idDiv);
     metaDiv.appendChild(statsDiv);
+    metaDiv.appendChild(discoveryDiv);
 
     const toggleDiv = document.createElement('div');
     toggleDiv.className = 'toggle';
@@ -3893,7 +3941,7 @@
     row.appendChild(metaDiv);
     row.appendChild(toggleDiv);
     row.appendChild(purgeBtn);
-    row._sctCache = { thumbDiv, thumbLink, dotDiv, link, statsDiv, toggleDiv };
+    row._sctCache = { thumbDiv, thumbLink, dotDiv, link, statsDiv, discoveryDiv, toggleDiv };
     row._sctLabelKey = buildPostLabelKey(p);
     row._sctThumbUrl = thumbChoice.displayUrl;
     row._sctThumbSourceUrl = thumbChoice.sourceUrl;
@@ -6105,7 +6153,7 @@ function makeTimeChart(canvas, tooltipSelector = '#viewsTooltip', yAxisLabel = '
       // === SHEET 1: Posts Summary (one row per post with latest snapshot) ===
       const postsHeader = [
         'User Key', 'User Handle', 'User ID', 
-        'Post ID', 'Post URL', 'Post Time', 'Post Time (ISO)', 'Caption',
+        'Post ID', 'Post URL', 'Post Time', 'Post Time (ISO)', 'Caption', 'Discovery Phrase',
         'Thumbnail URL', 'Parent Post ID', 'Root Post ID', 'Last Seen Timestamp',
         'Owner Key', 'Owner Handle', 'Owner ID',
         'Latest Snapshot Timestamp', 'Unique Views', 'Total Views', 'Likes', 'Comments', 'Remixes',
@@ -6137,6 +6185,7 @@ function makeTimeChart(canvas, tooltipSelector = '#viewsTooltip', yAxisLabel = '
           const lr = likeRate(likes, uv);
           
           const caption = (typeof post.caption === 'string' && post.caption) ? post.caption.replace(/\n/g, ' ').replace(/\r/g, '') : '';
+          const discoveryPhrase = (typeof post.discovery_phrase === 'string' && post.discovery_phrase) ? post.discovery_phrase.replace(/\n/g, ' ').replace(/\r/g, '') : '';
           const thumb = post.thumb || '';
           const url = post.url || `${SITE_ORIGIN}/p/${pid}`;
           const ownerKey = post.ownerKey || userKey;
@@ -6153,7 +6202,7 @@ function makeTimeChart(canvas, tooltipSelector = '#viewsTooltip', yAxisLabel = '
           
           allLines.push([
             userKey, handle, userId,
-            pid, url, postTime, postTimeISO, caption,
+            pid, url, postTime, postTimeISO, caption, discoveryPhrase,
             thumb, parentPostId, rootPostId, lastSeen,
             ownerKey, ownerHandle, ownerId,
             latestTime, uv, views, likes, comments, remixes,
@@ -6168,7 +6217,7 @@ function makeTimeChart(canvas, tooltipSelector = '#viewsTooltip', yAxisLabel = '
       allLines.push('=== POST SNAPSHOTS (Complete Historical Timeline) ===');
       const snapshotsHeader = [
         'User Key', 'User Handle', 'User ID',
-        'Post ID', 'Post URL', 'Post Caption', 'Post Time',
+        'Post ID', 'Post URL', 'Post Caption', 'Post Discovery Phrase', 'Post Time',
         'Owner Key', 'Owner Handle', 'Owner ID',
         'Snapshot Timestamp', 'Snapshot Timestamp (ISO)', 'Snapshot Age (minutes)',
         'Unique Views', 'Total Views', 'Likes', 'Comments', 'Remixes',
@@ -6186,6 +6235,7 @@ function makeTimeChart(canvas, tooltipSelector = '#viewsTooltip', yAxisLabel = '
           const postTimeRaw = getPostTimeStrict(post);
           const postTime = fmtTimestamp(postTimeRaw);
           const caption = (typeof post.caption === 'string' && post.caption) ? post.caption.replace(/\n/g, ' ').replace(/\r/g, '') : '';
+          const discoveryPhrase = (typeof post.discovery_phrase === 'string' && post.discovery_phrase) ? post.discovery_phrase.replace(/\n/g, ' ').replace(/\r/g, '') : '';
           const url = post.url || `${SITE_ORIGIN}/p/${pid}`;
           const ownerKey = post.ownerKey || userKey;
           const ownerHandle = post.ownerHandle || handle;
@@ -6216,7 +6266,7 @@ function makeTimeChart(canvas, tooltipSelector = '#viewsTooltip', yAxisLabel = '
             
             allLines.push([
               userKey, handle, userId,
-              pid, url, caption, postTime,
+              pid, url, caption, discoveryPhrase, postTime,
               ownerKey, ownerHandle, ownerId,
               tFormatted, tISO, ageMin,
               uv, views, likes, comments, remixes,
@@ -6592,6 +6642,7 @@ function makeTimeChart(canvas, tooltipSelector = '#viewsTooltip', yAxisLabel = '
         
         const url = getCol('Post URL') || `${SITE_ORIGIN}/p/${postId}`;
         const caption = getCol('Caption') || '';
+        const discoveryPhrase = getCol('Discovery Phrase') || '';
         const thumb = getCol('Thumbnail URL') || '';
         const postTimeISO = getCol('Post Time (ISO)') || getCol('Post Time');
         const postTime = parseTimestamp(postTimeISO);
@@ -6617,6 +6668,7 @@ function makeTimeChart(canvas, tooltipSelector = '#viewsTooltip', yAxisLabel = '
             url: url,
             thumb: thumb,
             caption: caption || null,
+            discovery_phrase: discoveryPhrase || null,
             snapshots: [],
             ownerKey: ownerKey,
             ownerHandle: ownerHandle,
@@ -6632,6 +6684,7 @@ function makeTimeChart(canvas, tooltipSelector = '#viewsTooltip', yAxisLabel = '
           if (!post.url && url) post.url = url;
           if (!post.thumb && thumb) post.thumb = thumb;
           if (!post.caption && caption) post.caption = caption;
+          if (!post.discovery_phrase && discoveryPhrase) post.discovery_phrase = discoveryPhrase;
           if (!post.ownerKey && ownerKey) post.ownerKey = ownerKey;
           if (!post.ownerHandle && ownerHandle) post.ownerHandle = ownerHandle;
           if (!post.ownerId && ownerId) post.ownerId = ownerId;
@@ -6675,6 +6728,7 @@ function makeTimeChart(canvas, tooltipSelector = '#viewsTooltip', yAxisLabel = '
         if (!user.posts[postId]) {
           const url = getCol('Post URL') || `${SITE_ORIGIN}/p/${postId}`;
           const caption = getCol('Post Caption') || '';
+          const discoveryPhrase = getCol('Post Discovery Phrase') || '';
           const postTimeISO = getCol('Post Time');
           const postTime = parseTimestamp(postTimeISO);
           const ownerKey = getCol('Owner Key') || userKey;
@@ -6685,6 +6739,7 @@ function makeTimeChart(canvas, tooltipSelector = '#viewsTooltip', yAxisLabel = '
             url: url,
             thumb: '',
             caption: caption || null,
+            discovery_phrase: discoveryPhrase || null,
             snapshots: [],
             ownerKey: ownerKey,
             ownerHandle: ownerHandle,
@@ -6802,6 +6857,13 @@ function makeTimeChart(canvas, tooltipSelector = '#viewsTooltip', yAxisLabel = '
         ultraModeEnabled = val;
       })
       .catch(() => {});
+    const discoveryPhraseToggle = $('#discoveryPhraseToggle');
+    const discoveryPhrasePrefPromise = loadDiscoveryPhrasePreference()
+      .then((val)=>{
+        showDiscoveryPhrase = !!val;
+        if (discoveryPhraseToggle) discoveryPhraseToggle.checked = showDiscoveryPhrase;
+      })
+      .catch(() => {});
     perfEnd(perfUltra);
     const modeTapEl = $('#dashboardModeTap');
     if (modeTapEl) {
@@ -6873,6 +6935,7 @@ function makeTimeChart(canvas, tooltipSelector = '#viewsTooltip', yAxisLabel = '
         'customFiltersByUser',
         'lastFilterAction',
         'lastFilterActionByUser',
+        DASHBOARD_DISCOVERY_PHRASE_STORAGE_KEY,
         VIEWS_TYPE_STORAGE_KEY,
         BEST_TIME_PREFS_KEY,
         CHART_MODE_STORAGE_KEY,
@@ -11077,6 +11140,7 @@ function makeTimeChart(canvas, tooltipSelector = '#viewsTooltip', yAxisLabel = '
         'lastUserKey',
         'zoomStates',
         ULTRA_MODE_STORAGE_KEY,
+        DASHBOARD_DISCOVERY_PHRASE_STORAGE_KEY,
         COMB_MODE_STORAGE_KEY
       ]
         .concat(Object.values(STACKED_WINDOW_STORAGE_KEYS))
@@ -12440,10 +12504,19 @@ function makeTimeChart(canvas, tooltipSelector = '#viewsTooltip', yAxisLabel = '
         refreshUserUI({ preserveEmpty: true, skipRestoreZoom: true }); persistVisibility();
       });
 
+      if (discoveryPhraseToggle) {
+        discoveryPhraseToggle.addEventListener('change', async (e) => {
+          showDiscoveryPhrase = !!e.target.checked;
+          await saveDiscoveryPhrasePreference(showDiscoveryPhrase);
+          await refreshUserUI({ preserveEmpty: true, skipRestoreZoom: true, skipCharts: true });
+        });
+      }
+
     // If compare section is empty on initial load, add current user to show who we're looking at
     if (compareUsers.size === 0 && currentUserKey && resolveUserForKey(metrics, currentUserKey)){
       addCompareUser(currentUserKey);
     }
+    await discoveryPhrasePrefPromise;
     const initialUser = resolveUserForKey(metrics, currentUserKey);
     if (initialUser) {
       const initAction = normalizeFilterAction(getSessionFilterAction(currentUserKey))
@@ -12506,6 +12579,10 @@ function makeTimeChart(canvas, tooltipSelector = '#viewsTooltip', yAxisLabel = '
       }
       zoomStates = st.zoomStates || {};
       zoomStatesLoaded = true;
+      if (Object.prototype.hasOwnProperty.call(st, DASHBOARD_DISCOVERY_PHRASE_STORAGE_KEY)) {
+        showDiscoveryPhrase = !!st[DASHBOARD_DISCOVERY_PHRASE_STORAGE_KEY];
+        if (discoveryPhraseToggle) discoveryPhraseToggle.checked = showDiscoveryPhrase;
+      }
       applyDefaultInteractionRateZoom(currentUserKey);
       if (st.lastFilterAction && (!lastFilterAction || lastFilterAction === 'showAll')) {
         lastFilterAction = st.lastFilterAction;

--- a/inject.js
+++ b/inject.js
@@ -38,6 +38,7 @@
 
   // == Configuration & Constants ==
   const PREF_KEY = 'SORA_UV_PREFS_V1';
+  const LEGACY_DISCOVERY_PHRASE_PREF_KEY = 'SCT_SHOW_DISCOVERY_PHRASE_V1';
   const SESS_KEY = 'SORA_UV_GATHER_STATE_V1';
   const ANALYZE_VISITED_KEY = 'SORA_UV_ANALYZE_VISITED';
   const ANALYZE_VISITED_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
@@ -76,6 +77,7 @@
   const idToDuration = new Map(); // Draft duration in seconds
   const idToDimensions = new Map(); // Video dimensions { width, height }
   const idToPrompt = new Map(); // Draft prompt text
+  const idToDiscoveryPhrase = new Map(); // Post discovery phrase
   const idToDownloadUrl = new Map(); // Draft downloadable URL
   const idToViolation = new Map(); // Draft content violation status
   const idToRemixTarget = new Map(); // Draft remix target post ID (if it's a remix of a post)
@@ -347,6 +349,64 @@
     if (typeof str !== 'string') return '';
     const s = str.replace(/\s+/g, ' ').trim();
     return s.length > max ? s.slice(0, max).trim() + '…' : s;
+  }
+
+  function normalizeDiscoveryPhrase(value) {
+    if (typeof value !== 'string') return null;
+    const phrase = value.replace(/\s+/g, ' ').trim();
+    return phrase || null;
+  }
+
+  function defaultDiscoveryPhrasePreference() {
+    return true;
+  }
+
+  function readDiscoveryPhrasePreferenceFromPrefs(prefs) {
+    if (prefs && typeof prefs.showDiscoveryPhrase === 'boolean') {
+      return prefs.showDiscoveryPhrase;
+    }
+    return defaultDiscoveryPhrasePreference();
+  }
+
+  function readLegacyDiscoveryPhrasePreference() {
+    try {
+      const legacy = localStorage.getItem(LEGACY_DISCOVERY_PHRASE_PREF_KEY);
+      if (legacy === '1') return true;
+      if (legacy === '0') return false;
+    } catch {}
+    return null;
+  }
+
+  function writeDiscoveryPhrasePreference(enabled) {
+    const prefs = getPrefs();
+    prefs.showDiscoveryPhrase = !!enabled;
+    setPrefs(prefs);
+    try {
+      localStorage.removeItem(LEGACY_DISCOVERY_PHRASE_PREF_KEY);
+    } catch {}
+    return prefs.showDiscoveryPhrase;
+  }
+
+  function discoveryPhraseEnabled() {
+    const prefs = getPrefs();
+    if (typeof prefs.showDiscoveryPhrase === 'boolean') {
+      return prefs.showDiscoveryPhrase;
+    }
+    const legacy = readLegacyDiscoveryPhrasePreference();
+    if (legacy != null) {
+      return writeDiscoveryPhrasePreference(legacy);
+    }
+    return defaultDiscoveryPhrasePreference();
+  }
+
+  function getDiscoveryPhraseForId(id) {
+    return normalizeDiscoveryPhrase(idToDiscoveryPhrase.get(id));
+  }
+
+  function formatDiscoveryPhrasePillText(phrase, max = 28) {
+    const normalized = normalizeDiscoveryPhrase(phrase);
+    if (!normalized) return null;
+    return truncateInline(normalized, max);
   }
 
   const ESC_MAP = { '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' };
@@ -1692,6 +1752,9 @@ function badgeEmojiFor(id, meta) {
     // Duration
     const duration = idToDuration.get(id);
     const durationStr = duration ? formatDuration(duration) : null;
+    const discoveryPhrase = discoveryPhraseEnabled() ? getDiscoveryPhraseForId(id) : null;
+    const discoveryPhraseStr = formatDiscoveryPhrasePillText(discoveryPhrase);
+    const discoveryPhraseTip = discoveryPhrase ? `Discovery phrase: ${discoveryPhrase}` : null;
 
     const viewsStr = uv != null ? `👀 ${fmt(uv)}` : null;
     const irStr = irDisp ? `${irDisp} IR` : null;
@@ -1715,7 +1778,7 @@ function badgeEmojiFor(id, meta) {
     badge.style.background = 'transparent';
     const pillBg = bg || 'rgba(37,37,37,0.7)';
 
-    const newKey = JSON.stringify([durationStr, viewsStr, irStr, rrStr, impactStr, timeEmojiStr, rateStr, flamesStr, pillBg]);
+    const newKey = JSON.stringify([durationStr, discoveryPhraseStr, viewsStr, irStr, rrStr, impactStr, timeEmojiStr, rateStr, flamesStr, pillBg]);
     if (badge.dataset.key === newKey) {
       badge.style.boxShadow = 'none';
       return;
@@ -1767,6 +1830,10 @@ function badgeEmojiFor(id, meta) {
       }
       const tooltip = `${durationStr}${modelName} video`;
       const el = createPill(badge, `${durationStr}`, tooltip, true);
+      el.style.background = pillBg;
+    }
+    if (discoveryPhraseStr) {
+      const el = createPill(badge, discoveryPhraseStr, discoveryPhraseTip, true);
       el.style.background = pillBg;
     }
     if (flamesStr) {
@@ -2080,6 +2147,8 @@ function badgeEmojiFor(id, meta) {
       if (metrics?.users) {
         // Helper function to load post data from a post object
         const loadPostData = (post, postId) => {
+          const discoveryPhrase = normalizeDiscoveryPhrase(post?.discovery_phrase);
+          if (discoveryPhrase) idToDiscoveryPhrase.set(postId, discoveryPhrase);
           const latest = __sorauv_latestSnapshot(post.snapshots);
           if (latest) {
             // Only set values if they're not null/undefined
@@ -2439,9 +2508,12 @@ function badgeEmojiFor(id, meta) {
     }
     
     const durationStr = duration ? formatDuration(duration) : null;
+    const discoveryPhrase = discoveryPhraseEnabled() ? getDiscoveryPhraseForId(sid) : null;
+    const discoveryPhraseStr = formatDiscoveryPhrasePillText(discoveryPhrase);
+    const discoveryPhraseTip = discoveryPhrase ? `Discovery phrase: ${discoveryPhrase}` : null;
 
     // Determine if we have any data to display
-    if (viewsStr == null && irStr == null && rrStr == null && impactStr == null && timeEmojiStr == null && durationStr == null && rateStr == null && !flamesStr) {
+    if (viewsStr == null && irStr == null && rrStr == null && impactStr == null && timeEmojiStr == null && durationStr == null && discoveryPhraseStr == null && rateStr == null && !flamesStr) {
       el.innerHTML = '';
       return;
     }
@@ -2449,7 +2521,7 @@ function badgeEmojiFor(id, meta) {
     // Use a key to prevent unnecessary DOM updates - match feed badge key format
     const bg = badgeBgFor(sid, meta);
     const pillBg = bg || 'rgba(37,37,37,0.7)';
-    const newKey = JSON.stringify([durationStr, viewsStr, irStr, rrStr, impactStr, timeEmojiStr, rateStr, flamesStr, pillBg]);
+    const newKey = JSON.stringify([durationStr, discoveryPhraseStr, viewsStr, irStr, rrStr, impactStr, timeEmojiStr, rateStr, flamesStr, pillBg]);
     const hasPills = el.querySelectorAll('.sora-uv-pill').length > 0;
     if (el.dataset.key === newKey && hasPills) return;
     el.dataset.key = newKey;
@@ -2521,7 +2593,14 @@ function badgeEmojiFor(id, meta) {
       metEl.style.pointerEvents = 'auto';
     }
 
-    // 7. Flames Pill - always last
+    // 7. Discovery Phrase Pill
+    if (discoveryPhraseStr) {
+      const phraseEl = createPill(el, discoveryPhraseStr, discoveryPhraseTip, true);
+      phraseEl.style.background = pillBg;
+      phraseEl.style.pointerEvents = 'auto';
+    }
+
+    // 8. Flames Pill - always last
     if (flamesStr) {
       const flameEl = createPill(el, flamesStr, flamesTip, true);
       flameEl.style.background = pillBg;
@@ -2997,7 +3076,79 @@ function badgeEmojiFor(id, meta) {
       };
       filterDropdown.appendChild(option);
     });
-    
+
+    const filterDivider = document.createElement('div');
+    Object.assign(filterDivider.style, {
+      height: '1px',
+      margin: '8px 4px',
+      background: 'rgba(255, 255, 255, 0.12)',
+    });
+    filterDropdown.appendChild(filterDivider);
+
+    const discoveryPhraseToggle = document.createElement('button');
+    discoveryPhraseToggle.type = 'button';
+    discoveryPhraseToggle.className = 'sora-uv-filter-option sora-uv-discovery-phrase-toggle';
+    Object.assign(discoveryPhraseToggle.style, {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      gap: '12px',
+      padding: '8px 12px',
+      background: 'transparent',
+      border: 'none',
+      color: 'var(--token-text-primary, #fff)',
+      textAlign: 'left',
+      cursor: 'pointer',
+      borderRadius: '8px',
+      fontSize: '14px',
+      fontWeight: '500',
+      transition: 'background 120ms ease',
+    });
+
+    const discoveryPhraseLabel = document.createElement('span');
+    discoveryPhraseLabel.textContent = 'Discovery phrase';
+    discoveryPhraseToggle.appendChild(discoveryPhraseLabel);
+
+    const discoveryPhraseState = document.createElement('span');
+    Object.assign(discoveryPhraseState.style, {
+      minWidth: '2.2em',
+      textAlign: 'right',
+      fontSize: '12px',
+      fontWeight: '700',
+      letterSpacing: '0.02em',
+      textTransform: 'uppercase',
+    });
+    discoveryPhraseToggle.appendChild(discoveryPhraseState);
+
+    const updateDiscoveryPhraseToggleState = () => {
+      const enabled = discoveryPhraseEnabled();
+      discoveryPhraseToggle.style.background = enabled
+        ? 'var(--token-bg-active, rgba(255, 255, 255, 0.15))'
+        : 'transparent';
+      discoveryPhraseToggle.style.fontWeight = enabled ? '600' : '500';
+      discoveryPhraseState.textContent = enabled ? 'On' : 'Off';
+      discoveryPhraseState.style.opacity = enabled ? '1' : '0.65';
+    };
+
+    discoveryPhraseToggle.onmouseenter = () => {
+      if (discoveryPhraseEnabled()) return;
+      discoveryPhraseToggle.style.background = 'var(--token-bg-light, rgba(255, 255, 255, 0.1))';
+    };
+    discoveryPhraseToggle.onmouseleave = () => {
+      updateDiscoveryPhraseToggleState();
+    };
+    discoveryPhraseToggle.onclick = (e) => {
+      e.stopPropagation();
+      writeDiscoveryPhrasePreference(!discoveryPhraseEnabled());
+      updateDiscoveryPhraseToggleState();
+      badgeDataGeneration++;
+      renderBadges();
+      renderDetailBadge();
+      filterDropdown.style.display = 'none';
+    };
+    updateDiscoveryPhraseToggleState();
+    filterDropdown.appendChild(discoveryPhraseToggle);
+
     filterContainer.appendChild(filterDropdown);
     buttonRow.appendChild(filterContainer);
 
@@ -5796,8 +5947,10 @@ async function renderAnalyzeTable(force = false) {
         p?.created_at ?? p?.uploaded_at ?? p?.createdAt ?? p?.created ?? p?.posted_at ?? p?.timestamp ?? null;
       const caption =
         (typeof p?.caption === 'string' && p.caption) ? p.caption : (typeof p?.text === 'string' && p.text ? p.text : null);
+      const discoveryPhrase = normalizeDiscoveryPhrase(p?.discovery_phrase);
       const ageMin = minutesSince(created_at);
       const th = getThumbnail(it);
+      if (discoveryPhrase) idToDiscoveryPhrase.set(id, discoveryPhrase);
 
       // Extract video duration from n_frames (Sora uses 30 fps for published posts)
       try {
@@ -5949,6 +6102,7 @@ async function renderAnalyzeTable(force = false) {
         followers,
         created_at,
         caption,
+        discovery_phrase: discoveryPhrase,
         ageMin,
         thumb: th,
         url: absUrl,
@@ -5989,8 +6143,10 @@ async function renderAnalyzeTable(force = false) {
           const remixP = remixItem?.post || remixItem || {};
           const remixCreatedAt = remixP?.created_at ?? remixP?.uploaded_at ?? remixP?.createdAt ?? remixP?.created ?? remixP?.posted_at ?? remixP?.timestamp ?? null;
           const remixCaption = (typeof remixP?.caption === 'string' && remixP.caption) ? remixP.caption : (typeof remixP?.text === 'string' && remixP.text ? remixP.text : null);
+          const remixDiscoveryPhrase = normalizeDiscoveryPhrase(remixP?.discovery_phrase);
           const remixAgeMin = minutesSince(remixCreatedAt);
           const remixTh = getThumbnail(remixItem);
+          if (remixDiscoveryPhrase) idToDiscoveryPhrase.set(remixId, remixDiscoveryPhrase);
           
           // Extract duration and dimensions for remix
           try {
@@ -6077,6 +6233,7 @@ async function renderAnalyzeTable(force = false) {
             followers: remixFollowers,
             created_at: remixCreatedAt,
             caption: remixCaption,
+            discovery_phrase: remixDiscoveryPhrase,
             ageMin: remixAgeMin,
             thumb: remixTh,
             url: remixAbsUrl,
@@ -7450,7 +7607,15 @@ async function renderAnalyzeTable(force = false) {
     }
     if (e.key !== PREF_KEY) return;
     try {
+      const oldPrefs = JSON.parse(e.oldValue || '{}');
       const newPrefs = JSON.parse(e.newValue || '{}');
+      const oldShowDiscoveryPhrase = readDiscoveryPhrasePreferenceFromPrefs(oldPrefs);
+      const newShowDiscoveryPhrase = readDiscoveryPhrasePreferenceFromPrefs(newPrefs);
+      if (oldShowDiscoveryPhrase !== newShowDiscoveryPhrase) {
+        badgeDataGeneration++;
+        renderBadges();
+        renderDetailBadge();
+      }
       if (newPrefs.gatherSpeed == null) return;
       const slider = document.querySelector('.sora-uv-controls input[type="range"]');
       if (slider && slider.value !== newPrefs.gatherSpeed) slider.value = newPrefs.gatherSpeed;

--- a/tests/dashboard-discovery-phrase.regression.test.js
+++ b/tests/dashboard-discovery-phrase.regression.test.js
@@ -1,0 +1,373 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const DASHBOARD_PATH = path.join(__dirname, '..', 'dashboard.js');
+const DASHBOARD_SRC = fs.readFileSync(DASHBOARD_PATH, 'utf8');
+
+function extractBetween(startMarker, endMarker) {
+  const start = DASHBOARD_SRC.indexOf(startMarker);
+  assert.notEqual(start, -1, `start marker not found: ${startMarker}`);
+  const end = DASHBOARD_SRC.indexOf(endMarker, start);
+  assert.notEqual(end, -1, `end marker not found: ${endMarker}`);
+  return DASHBOARD_SRC.slice(start, end);
+}
+
+function extractConstString(name) {
+  const match = DASHBOARD_SRC.match(new RegExp(`const ${name} = '([^']+)';`));
+  assert.ok(match, `constant not found: ${name}`);
+  return match[1];
+}
+
+function buildPreferenceHarness() {
+  const storageKey = extractConstString('DASHBOARD_DISCOVERY_PHRASE_STORAGE_KEY');
+  const snippet = extractBetween('async function loadDiscoveryPhrasePreference(){', 'function num(v){');
+  const state = {
+    storedValue: undefined,
+    setCalls: [],
+  };
+  const context = {
+    __state: state,
+  };
+  const bootstrap = `
+    const DASHBOARD_DISCOVERY_PHRASE_STORAGE_KEY = ${JSON.stringify(storageKey)};
+    const chrome = {
+      storage: {
+        local: {
+          async get(key) {
+            const state = globalThis.__state;
+            if (state.storedValue === undefined) return {};
+            return { [key]: state.storedValue };
+          },
+          async set(payload) {
+            globalThis.__state.setCalls.push(payload);
+            globalThis.__state.storedValue = payload[DASHBOARD_DISCOVERY_PHRASE_STORAGE_KEY];
+          }
+        }
+      }
+    };
+    ${snippet}
+    globalThis.__loadDiscoveryPhrasePreference = loadDiscoveryPhrasePreference;
+    globalThis.__saveDiscoveryPhrasePreference = saveDiscoveryPhrasePreference;
+  `;
+  vm.createContext(context);
+  vm.runInContext(bootstrap, context, { filename: 'dashboard-discovery-pref-harness.js' });
+  return {
+    state,
+    loadDiscoveryPhrasePreference: context.__loadDiscoveryPhrasePreference,
+    saveDiscoveryPhrasePreference: context.__saveDiscoveryPhrasePreference,
+    storageKey,
+  };
+}
+
+function buildLineHarness() {
+  const snippet = extractBetween('function normalizeDiscoveryPhrase(value) {', 'function truncateForPurgeCaption(text){');
+  const context = {};
+  const bootstrap = `
+    ${snippet}
+    globalThis.__normalizeDiscoveryPhrase = normalizeDiscoveryPhrase;
+    globalThis.__buildDiscoveryPhraseLine = buildDiscoveryPhraseLine;
+  `;
+  vm.createContext(context);
+  vm.runInContext(bootstrap, context, { filename: 'dashboard-discovery-line-harness.js' });
+  return {
+    normalizeDiscoveryPhrase: context.__normalizeDiscoveryPhrase,
+    buildDiscoveryPhraseLine: context.__buildDiscoveryPhraseLine,
+  };
+}
+
+function latestSnapshot(snaps) {
+  if (!Array.isArray(snaps) || snaps.length === 0) return null;
+  return snaps[snaps.length - 1] || null;
+}
+
+function getPostTimeStrict(post) {
+  return post?.post_time || null;
+}
+
+function interactionRate(snap) {
+  const uv = Number(snap?.uv);
+  if (!Number.isFinite(uv) || uv <= 0) return null;
+  const likes = Number(snap?.likes) || 0;
+  const comments = Number(snap?.comments ?? snap?.reply_count) || 0;
+  return ((likes + comments) / uv) * 100;
+}
+
+function remixRate(likes, remixes) {
+  const l = Number(likes);
+  const r = Number(remixes);
+  if (!Number.isFinite(l) || l <= 0 || !Number.isFinite(r) || r < 0) return null;
+  return ((r / l) * 100).toFixed(2);
+}
+
+function likeRate(likes, uv) {
+  const l = Number(likes);
+  const u = Number(uv);
+  if (!Number.isFinite(l) || l < 0 || !Number.isFinite(u) || u <= 0) return null;
+  return (l / u) * 100;
+}
+
+function toTs(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) return value < 1e11 ? value * 1000 : value;
+  if (typeof value === 'string' && value.trim()) {
+    const text = value.trim();
+    if (/^\d+$/.test(text)) {
+      const parsed = Number(text);
+      return parsed < 1e11 ? parsed * 1000 : parsed;
+    }
+    const parsedDate = Date.parse(text);
+    if (!Number.isNaN(parsedDate)) return parsedDate;
+  }
+  return 0;
+}
+
+function computeTotalsForUser(user) {
+  const totals = { views: 0, likes: 0, replies: 0, remixes: 0, interactions: 0 };
+  for (const post of Object.values(user?.posts || {})) {
+    const latest = latestSnapshot(post?.snapshots);
+    if (!latest) continue;
+    totals.views += Number(latest.views) || 0;
+    totals.likes += Number(latest.likes) || 0;
+    totals.replies += Number(latest.comments ?? latest.reply_count) || 0;
+    totals.remixes += Number(latest.remix_count ?? latest.remixes) || 0;
+  }
+  totals.interactions = totals.likes + totals.replies;
+  return totals;
+}
+
+function buildExportHarness(metricsFixture) {
+  const snippet = extractBetween('function escapeCSV(str) {', '\n  // Parse CSV line handling quoted fields');
+  const state = {
+    blob: null,
+    clickCount: 0,
+    revokedUrl: null,
+  };
+  const context = {
+    __metricsFixture: metricsFixture,
+    __state: state,
+    __latestSnapshot: latestSnapshot,
+    __getPostTimeStrict: getPostTimeStrict,
+    __interactionRate: interactionRate,
+    __remixRate: remixRate,
+    __likeRate: likeRate,
+    __computeTotalsForUser: computeTotalsForUser,
+    __toTs: toTs,
+  };
+  const bootstrap = `
+    const SITE_ORIGIN = 'https://sora.chatgpt.com';
+    const loadMetrics = async () => globalThis.__metricsFixture;
+    const ensureFullSnapshots = async () => {};
+    const latestSnapshot = globalThis.__latestSnapshot;
+    const getPostTimeStrict = globalThis.__getPostTimeStrict;
+    const interactionRate = globalThis.__interactionRate;
+    const remixRate = globalThis.__remixRate;
+    const likeRate = globalThis.__likeRate;
+    const computeTotalsForUser = globalThis.__computeTotalsForUser;
+    const toTs = globalThis.__toTs;
+    const alert = () => { throw new Error('unexpected alert during export'); };
+    class Blob {
+      constructor(parts, opts = {}) {
+        this.parts = parts;
+        this.type = opts.type || '';
+      }
+    }
+    const URL = {
+      createObjectURL(blob) {
+        globalThis.__state.blob = blob;
+        return 'blob:test';
+      },
+      revokeObjectURL(url) {
+        globalThis.__state.revokedUrl = url;
+      }
+    };
+    const document = {
+      body: {
+        appendChild() {},
+        removeChild() {}
+      },
+      createElement(tag) {
+        if (tag !== 'a') return {};
+        return {
+          href: '',
+          download: '',
+          click() {
+            globalThis.__state.clickCount += 1;
+          }
+        };
+      }
+    };
+    const setTimeout = (fn) => { fn(); return 1; };
+    ${snippet}
+    globalThis.__exportAllDataCSV = exportAllDataCSV;
+  `;
+  vm.createContext(context);
+  vm.runInContext(bootstrap, context, { filename: 'dashboard-discovery-export-harness.js' });
+  return {
+    state,
+    exportAllDataCSV: context.__exportAllDataCSV,
+  };
+}
+
+function buildImportHarness() {
+  const snippet = extractBetween('function parseCSVLine(line) {', '\n  async function main(prefetchedCache){');
+  const context = {
+    __toTs: toTs,
+  };
+  const bootstrap = `
+    const SITE_ORIGIN = 'https://sora.chatgpt.com';
+    const toTs = globalThis.__toTs;
+    ${snippet}
+    globalThis.__importDataCSVText = importDataCSVText;
+  `;
+  vm.createContext(context);
+  vm.runInContext(bootstrap, context, { filename: 'dashboard-discovery-import-harness.js' });
+  return {
+    importDataCSVText: context.__importDataCSVText,
+  };
+}
+
+test('dashboard discovery phrase preference defaults to true and saves to the dashboard-specific key', async () => {
+  const harness = buildPreferenceHarness();
+
+  assert.equal(await harness.loadDiscoveryPhrasePreference(), true);
+
+  await harness.saveDiscoveryPhrasePreference(false);
+  assert.equal(harness.state.setCalls.length, 1);
+  assert.equal(harness.state.setCalls[0][harness.storageKey], false);
+  assert.equal(await harness.loadDiscoveryPhrasePreference(), false);
+});
+
+test('buildDiscoveryPhraseLine normalizes whitespace and returns empty for missing phrases', () => {
+  const { normalizeDiscoveryPhrase, buildDiscoveryPhraseLine } = buildLineHarness();
+
+  assert.equal(normalizeDiscoveryPhrase('  delft   pottery \n organ   pug  '), 'delft pottery organ pug');
+  assert.equal(buildDiscoveryPhraseLine({ discovery_phrase: '  delft   pottery \n organ   pug  ' }), 'delft pottery organ pug');
+  assert.equal(buildDiscoveryPhraseLine({ discovery_phrase: '   ' }), '');
+  assert.equal(buildDiscoveryPhraseLine({}), '');
+});
+
+test('exportAllDataCSV includes discovery phrase columns and values', async () => {
+  const metricsFixture = {
+    users: {
+      'h:alice': {
+        handle: 'alice',
+        id: 'user-1',
+        posts: {
+          's_123': {
+            url: 'https://sora.chatgpt.com/p/s_123',
+            caption: 'Delft Pug',
+            discovery_phrase: 'delft pottery organ pug',
+            post_time: 1773541644483,
+            snapshots: [
+              { t: 1773541932509, uv: 27, views: 37, likes: 9, comments: 1, remix_count: 0 }
+            ]
+          }
+        },
+        followers: [],
+        cameos: []
+      }
+    }
+  };
+
+  const harness = buildExportHarness(metricsFixture);
+  await harness.exportAllDataCSV();
+
+  assert.equal(harness.state.clickCount, 1);
+  assert.ok(harness.state.blob, 'expected blob to be created');
+
+  const csv = harness.state.blob.parts.join('');
+  assert.match(csv, /Discovery Phrase/);
+  assert.match(csv, /Post Discovery Phrase/);
+  assert.match(csv, /delft pottery organ pug/);
+});
+
+test('discovery phrases survive export/import round-trip through dashboard CSV', async () => {
+  const metricsFixture = {
+    users: {
+      'h:alice': {
+        handle: 'alice',
+        id: 'user-1',
+        posts: {
+          's_123': {
+            url: 'https://sora.chatgpt.com/p/s_123',
+            caption: 'Delft Pug',
+            discovery_phrase: 'delft pottery organ pug',
+            post_time: 1773541644483,
+            snapshots: [
+              { t: 1773541932509, uv: 27, views: 37, likes: 9, comments: 1, remix_count: 0 }
+            ]
+          }
+        },
+        followers: [],
+        cameos: []
+      }
+    }
+  };
+
+  const exportHarness = buildExportHarness(metricsFixture);
+  await exportHarness.exportAllDataCSV();
+  const csv = exportHarness.state.blob.parts.join('');
+
+  const importHarness = buildImportHarness();
+  const importedMetrics = { users: {} };
+  const stats = {
+    postsAdded: 0,
+    postsUpdated: 0,
+    snapshotsAdded: 0,
+    snapshotsSkipped: 0,
+    followersAdded: 0,
+    followersSkipped: 0,
+    cameosAdded: 0,
+    cameosSkipped: 0,
+    usersAdded: 0,
+    usersUpdated: 0,
+  };
+
+  const didImport = await importHarness.importDataCSVText(csv, importedMetrics, stats);
+  assert.equal(didImport, true);
+  assert.equal(importedMetrics.users['h:alice'].posts['s_123'].discovery_phrase, 'delft pottery organ pug');
+});
+
+test('importDataCSVText does not overwrite an existing discovery phrase with a blank CSV field', async () => {
+  const importHarness = buildImportHarness();
+  const metrics = {
+    users: {
+      'h:alice': {
+        handle: 'alice',
+        id: 'user-1',
+        posts: {
+          's_123': {
+            url: 'https://sora.chatgpt.com/p/s_123',
+            discovery_phrase: 'keep existing phrase',
+            snapshots: []
+          }
+        },
+        followers: [],
+        cameos: []
+      }
+    }
+  };
+  const stats = {
+    postsAdded: 0,
+    postsUpdated: 0,
+    snapshotsAdded: 0,
+    snapshotsSkipped: 0,
+    followersAdded: 0,
+    followersSkipped: 0,
+    cameosAdded: 0,
+    cameosSkipped: 0,
+    usersAdded: 0,
+    usersUpdated: 0,
+  };
+  const csv = [
+    '=== POSTS SUMMARY (Latest Snapshot Per Post) ===',
+    'User Key,User Handle,User ID,Post ID,Post URL,Post Time,Post Time (ISO),Caption,Discovery Phrase,Thumbnail URL,Parent Post ID,Root Post ID,Last Seen Timestamp,Owner Key,Owner Handle,Owner ID,Latest Snapshot Timestamp,Unique Views,Total Views,Likes,Comments,Remixes,Interaction Rate %,Remix Rate %,Like Rate %,Snapshot Count,First Snapshot Timestamp,Last Snapshot Timestamp',
+    'h:alice,alice,user-1,s_123,https://sora.chatgpt.com/p/s_123,,,,,https://thumb.example/image.jpg,,,,h:alice,alice,user-1,2026-03-15T01:00:00.000Z,27,37,9,1,0,37.04,0,33.33,1,2026-03-15T01:00:00.000Z,2026-03-15T01:00:00.000Z'
+  ].join('\n');
+
+  const didImport = await importHarness.importDataCSVText(csv, metrics, stats);
+  assert.equal(didImport, true);
+  assert.equal(metrics.users['h:alice'].posts['s_123'].discovery_phrase, 'keep existing phrase');
+});

--- a/tests/inject-discovery-phrase.regression.test.js
+++ b/tests/inject-discovery-phrase.regression.test.js
@@ -1,0 +1,182 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const INJECT_PATH = path.join(__dirname, '..', 'inject.js');
+
+function extractConstString(src, name) {
+  const match = src.match(new RegExp(`const ${name} = '([^']+)';`));
+  assert.ok(match, `could not find const ${name}`);
+  return match[1];
+}
+
+function toPlain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function buildDiscoveryPhraseHarness() {
+  const src = fs.readFileSync(INJECT_PATH, 'utf8');
+  const prefsStart = src.indexOf('  function getPrefs() {');
+  assert.notEqual(prefsStart, -1, 'inject prefs snippet start not found');
+  const prefsEnd = src.indexOf('  // == Bookmarks (Drafts) ==', prefsStart);
+  assert.notEqual(prefsEnd, -1, 'inject prefs snippet end not found');
+  const prefsSnippet = src.slice(prefsStart, prefsEnd);
+
+  const discoveryStart = src.indexOf('  function defaultDiscoveryPhrasePreference() {');
+  assert.notEqual(discoveryStart, -1, 'inject discovery snippet start not found');
+  const discoveryEnd = src.indexOf('  function getDiscoveryPhraseForId(id) {', discoveryStart);
+  assert.notEqual(discoveryEnd, -1, 'inject discovery snippet end not found');
+  const discoverySnippet = src.slice(discoveryStart, discoveryEnd);
+
+  const storageStart = src.indexOf('  function handleStorageChange(e) {');
+  assert.notEqual(storageStart, -1, 'inject storage snippet start not found');
+  const storageEnd = src.indexOf('  // Inject dashboard button into left sidebar', storageStart);
+  assert.notEqual(storageEnd, -1, 'inject storage snippet end not found');
+  const storageSnippet = src.slice(storageStart, storageEnd);
+
+  const context = {};
+  const bootstrap = `
+    const PREF_KEY = ${JSON.stringify(extractConstString(src, 'PREF_KEY'))};
+    const LEGACY_DISCOVERY_PHRASE_PREF_KEY = ${JSON.stringify(extractConstString(src, 'LEGACY_DISCOVERY_PHRASE_PREF_KEY'))};
+    const VIDEO_GENS_BALANCE_KEY = ${JSON.stringify(extractConstString(src, 'VIDEO_GENS_BALANCE_KEY'))};
+    let badgeDataGeneration = 0;
+    let renderBadgesCalls = 0;
+    let renderDetailBadgeCalls = 0;
+    let injectSidebarGensCounterCalls = 0;
+    let startGatheringCalls = 0;
+    let isGatheringActiveThisTab = false;
+
+    const document = {
+      querySelector() {
+        return null;
+      },
+    };
+
+    const storage = new Map();
+    const localStorage = {
+      getItem(key) {
+        return storage.has(key) ? storage.get(key) : null;
+      },
+      setItem(key, value) {
+        storage.set(key, String(value));
+      },
+      removeItem(key) {
+        storage.delete(key);
+      },
+    };
+
+    function renderBadges() {
+      renderBadgesCalls++;
+    }
+    function renderDetailBadge() {
+      renderDetailBadgeCalls++;
+    }
+    function injectSidebarGensCounter() {
+      injectSidebarGensCounterCalls++;
+    }
+    function isTopFeed() {
+      return false;
+    }
+    function startGathering() {
+      startGatheringCalls++;
+    }
+
+${prefsSnippet}
+${discoverySnippet}
+${storageSnippet}
+
+    function readStoredPrefs() {
+      try {
+        return JSON.parse(localStorage.getItem(PREF_KEY) || '{}');
+      } catch {
+        return {};
+      }
+    }
+
+    function reset() {
+      storage.clear();
+      badgeDataGeneration = 0;
+      renderBadgesCalls = 0;
+      renderDetailBadgeCalls = 0;
+      injectSidebarGensCounterCalls = 0;
+      startGatheringCalls = 0;
+      isGatheringActiveThisTab = false;
+    }
+
+    globalThis.__injectDiscoveryApi = {
+      reset,
+      getPrefs,
+      setPrefs,
+      discoveryPhraseEnabled,
+      writeDiscoveryPhrasePreference,
+      readStoredPrefs,
+      handleStorageChange,
+      getLegacyValue: () => localStorage.getItem(LEGACY_DISCOVERY_PHRASE_PREF_KEY),
+      setLegacyValue: (value) => localStorage.setItem(LEGACY_DISCOVERY_PHRASE_PREF_KEY, value),
+      setRawPrefsValue: (value) => localStorage.setItem(PREF_KEY, value),
+      getState: () => ({
+        badgeDataGeneration,
+        renderBadgesCalls,
+        renderDetailBadgeCalls,
+        injectSidebarGensCounterCalls,
+        startGatheringCalls,
+      }),
+      getPrefKey: () => PREF_KEY,
+    };
+  `;
+
+  vm.createContext(context);
+  vm.runInContext(bootstrap, context, { filename: 'inject-discovery-phrase-harness.js' });
+  return context.__injectDiscoveryApi;
+}
+
+test('content discovery phrases default to enabled without stored prefs', () => {
+  const api = buildDiscoveryPhraseHarness();
+  api.reset();
+
+  assert.equal(api.discoveryPhraseEnabled(), true);
+  assert.deepEqual(toPlain(api.readStoredPrefs()), {});
+});
+
+test('content discovery phrase preference migrates legacy standalone storage key', () => {
+  const api = buildDiscoveryPhraseHarness();
+  api.reset();
+  api.setLegacyValue('0');
+
+  assert.equal(api.discoveryPhraseEnabled(), false);
+  assert.deepEqual(toPlain(api.readStoredPrefs()), { showDiscoveryPhrase: false });
+  assert.equal(api.getLegacyValue(), null);
+});
+
+test('content discovery phrase preference writes into shared prefs', () => {
+  const api = buildDiscoveryPhraseHarness();
+  api.reset();
+
+  assert.equal(api.writeDiscoveryPhrasePreference(false), false);
+  assert.deepEqual(toPlain(api.readStoredPrefs()), { showDiscoveryPhrase: false });
+
+  assert.equal(api.writeDiscoveryPhrasePreference(true), true);
+  assert.deepEqual(toPlain(api.readStoredPrefs()), { showDiscoveryPhrase: true });
+});
+
+test('prefs storage changes rerender badges when discovery phrase visibility changes', () => {
+  const api = buildDiscoveryPhraseHarness();
+  api.reset();
+
+  const prefKey = api.getPrefKey();
+  api.handleStorageChange({
+    key: prefKey,
+    oldValue: JSON.stringify({ showDiscoveryPhrase: true }),
+    newValue: JSON.stringify({ showDiscoveryPhrase: false }),
+  });
+
+  assert.deepEqual(toPlain(api.getState()), {
+    badgeDataGeneration: 1,
+    renderBadgesCalls: 1,
+    renderDetailBadgeCalls: 1,
+    injectSidebarGensCounterCalls: 0,
+    startGatheringCalls: 0,
+  });
+});

--- a/tests/metrics-key-sanitization.regression.test.js
+++ b/tests/metrics-key-sanitization.regression.test.js
@@ -130,3 +130,23 @@ test('sanitizers still reject payloads with no metrics signal', () => {
     null
   );
 });
+
+test('sanitizers preserve discovery phrases when a metrics signal is present', () => {
+  const sanitizeMetricsItem = buildContentSanitizerHarness();
+  const sanitizeMetricsSnapshot = buildBackgroundSanitizerHarness();
+  const discoveryPhrase = 'delft   pottery \n organ   pug';
+  const payload = {
+    userKey: 'h:alice.sora',
+    postId: 's_123',
+    likes: 4,
+    discovery_phrase: `  ${discoveryPhrase}  `,
+  };
+
+  const contentOut = sanitizeMetricsItem(payload);
+  const backgroundOut = sanitizeMetricsSnapshot(payload);
+
+  assert.ok(contentOut);
+  assert.ok(backgroundOut);
+  assert.equal(contentOut.discovery_phrase, discoveryPhrase);
+  assert.equal(backgroundOut.discovery_phrase, discoveryPhrase);
+});


### PR DESCRIPTION
# Add discovery phrase support across content and dashboard

Capture, persist, and surface Sora post discovery phrases throughout the extension while keeping dashboard and in-page controls independent.

This change threads `discovery_phrase` through the metrics pipeline so it is sanitized, stored, merged, exported, and imported alongside existing post metadata. Dashboard views can now display discovery phrases for each video, and CSV round-trips preserve them without overwriting existing values with blank imports.

On the content side, discovery phrases remain visible in Sora and are now controlled by a content-owned toggle in the filter menu instead of being tied to the dashboard preference. The legacy standalone discovery-phrase storage key is migrated into shared content prefs, and the old background/content relay path has been removed so dashboard settings no longer affect page UI.

Tests add coverage for:
- dashboard discovery phrase preference behavior
- dashboard discovery phrase rendering and normalization
- CSV export/import round-trip preservation
- blank import non-destructive behavior
- content discovery phrase default-on behavior
- legacy preference migration into shared prefs
- badge rerendering when content discovery phrase visibility changes

Files touched:
- `inject.js`
- `dashboard.js`
- `dashboard.html`
- `background.js`
- `content.js`
- `tests/dashboard-discovery-phrase.regression.test.js`
- `tests/inject-discovery-phrase.regression.test.js`
- `tests/metrics-key-sanitization.regression.test.js`

Verification:
- `for f in *.js tests/*.js; do node --check "$f"; done`
- `node --test tests/*.test.js`
- `git diff --check`

Created with Codex

<img width="481" height="716" alt="Screenshot 2026-03-15 at 1 40 36 PM" src="https://github.com/user-attachments/assets/703cc54e-1415-47bf-b488-792a3facd2c6" />

<img width="465" height="733" alt="Screenshot 2026-03-15 at 1 40 41 PM" src="https://github.com/user-attachments/assets/0f579ccb-d8b5-48d6-8f91-856159742024" />

<img width="1084" height="637" alt="Screenshot 2026-03-15 at 1 41 57 PM" src="https://github.com/user-attachments/assets/2877630b-c21f-4ae1-9d73-c208594f81fd" />

