### PR TITLE
fix: prevent duplicate Activity pills from accumulating in docked controls

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -3407,10 +3407,29 @@ function badgeEmojiFor(id, meta) {
     return candidates[0]?.btn || null;
   }
 
+  function clearActivityDockSlot(bar, keepNode = null) {
+    const dockSlot = bar?._activityDockSlot;
+    if (!dockSlot) return;
+    const children = Array.from(dockSlot.children || []);
+    for (const child of children) {
+      if (keepNode && child === keepNode) continue;
+      try {
+        if (typeof child.remove === 'function') child.remove();
+        else if (child.parentNode === dockSlot && typeof dockSlot.removeChild === 'function') dockSlot.removeChild(child);
+      } catch {}
+    }
+  }
+
   function undockActivityButton(bar) {
     if (!bar) return;
     const state = bar._activityDockState;
-    if (!state) return;
+    if (!state) {
+      clearActivityDockSlot(bar);
+      if (bar._activityDockSlot) {
+        bar._activityDockSlot.style.display = 'none';
+      }
+      return;
+    }
     const node = state.node;
     const parent = state.originalParent;
     const nextSibling = state.originalNextSibling;
@@ -3419,11 +3438,16 @@ function badgeEmojiFor(id, meta) {
     if (node && parent && parent.isConnected) {
       if (nextSibling && nextSibling.parentNode === parent) parent.insertBefore(node, nextSibling);
       else parent.appendChild(node);
+    } else if (node && bar._activityDockSlot && bar._activityDockSlot.contains(node)) {
+      try {
+        if (typeof node.remove === 'function') node.remove();
+      } catch {}
     }
     if (state.nativeContainer && state.nativeContainer.isConnected) {
       state.nativeContainer.style.display = state.nativeDisplay || '';
     }
     if (bar._activityDockSlot) {
+      clearActivityDockSlot(bar);
       bar._activityDockSlot.style.display = 'none';
     }
     bar._activityDockState = null;
@@ -3433,6 +3457,7 @@ function badgeEmojiFor(id, meta) {
     if (!bar || !bar._buttonRow) return;
     const existingState = bar._activityDockState;
     if (existingState?.node && bar._activityDockSlot && bar._activityDockSlot.contains(existingState.node)) {
+      clearActivityDockSlot(bar, existingState.node);
       bar._activityDockSlot.style.display = 'flex';
       return;
     }
@@ -3462,6 +3487,7 @@ function badgeEmojiFor(id, meta) {
     const nodeMarginLeft = moveNode.style.marginLeft;
     const nodeMarginRight = moveNode.style.marginRight;
     undockActivityButton(bar);
+    clearActivityDockSlot(bar);
     bar._activityDockState = {
       node: moveNode,
       originalParent: moveNode.parentNode,

--- a/tests/inject-activity-docking.regression.test.js
+++ b/tests/inject-activity-docking.regression.test.js
@@ -1,0 +1,163 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const INJECT_PATH = path.join(__dirname, '..', 'inject.js');
+
+class MockNode {
+  constructor(name) {
+    this.name = name;
+    this.parentNode = null;
+    this.children = [];
+    this.style = {};
+    this.isConnected = false;
+    this._closestMap = new Map();
+  }
+
+  appendChild(child) {
+    if (child.parentNode) child.parentNode.removeChild(child);
+    this.children.push(child);
+    child.parentNode = this;
+    child.isConnected = this.isConnected;
+    return child;
+  }
+
+  insertBefore(child, nextSibling) {
+    if (child.parentNode) child.parentNode.removeChild(child);
+    const idx = this.children.indexOf(nextSibling);
+    if (idx === -1) return this.appendChild(child);
+    this.children.splice(idx, 0, child);
+    child.parentNode = this;
+    child.isConnected = this.isConnected;
+    return child;
+  }
+
+  removeChild(child) {
+    const idx = this.children.indexOf(child);
+    if (idx !== -1) this.children.splice(idx, 1);
+    child.parentNode = null;
+    child.isConnected = false;
+    return child;
+  }
+
+  remove() {
+    if (this.parentNode) this.parentNode.removeChild(this);
+  }
+
+  contains(node) {
+    if (node === this) return true;
+    return this.children.some((child) => child.contains(node));
+  }
+
+  closest(selector) {
+    return this._closestMap.get(selector) || null;
+  }
+
+  setClosest(selector, node) {
+    this._closestMap.set(selector, node);
+  }
+}
+
+function connectTree(node) {
+  node.isConnected = true;
+  for (const child of node.children) connectTree(child);
+}
+
+function buildHarness() {
+  const src = fs.readFileSync(INJECT_PATH, 'utf8');
+  const start = src.indexOf('  function findTopRightActivityButton() {');
+  assert.notEqual(start, -1, 'activity docking snippet start not found');
+  const end = src.indexOf('\n  function syncActivityButtonDocking(bar, shouldDock) {', start);
+  assert.notEqual(end, -1, 'activity docking snippet end not found');
+  const snippet = src.slice(start, end);
+
+  const context = {
+    Array,
+    Math,
+    document: {
+      documentElement: { clientWidth: 0, clientHeight: 0 },
+      querySelectorAll() {
+        return [];
+      },
+    },
+    window: {
+      innerWidth: 0,
+      innerHeight: 0,
+    },
+    controlBar: null,
+  };
+
+  vm.createContext(context);
+  vm.runInContext(
+    `${snippet}
+    globalThis.__activityDockApi = {
+      clearActivityDockSlot,
+      undockActivityButton,
+      dockActivityButton,
+    };`,
+    context,
+    { filename: 'inject-activity-docking-harness.js' }
+  );
+  return context.__activityDockApi;
+}
+
+test('undockActivityButton removes stale docked activity nodes when their original parent was remounted away', () => {
+  const api = buildHarness();
+  const buttonRow = new MockNode('buttonRow');
+  const dockSlot = new MockNode('dockSlot');
+  const staleNode = new MockNode('staleNode');
+  const bar = {
+    _buttonRow: buttonRow,
+    _activityDockSlot: dockSlot,
+    _activityDockState: {
+      node: staleNode,
+      originalParent: { isConnected: false },
+      originalNextSibling: null,
+      nativeContainer: null,
+      nativeDisplay: '',
+      nodeMarginLeft: '',
+      nodeMarginRight: '',
+    },
+  };
+  buttonRow.appendChild(dockSlot);
+  dockSlot.appendChild(staleNode);
+  connectTree(buttonRow);
+
+  api.undockActivityButton(bar);
+
+  assert.equal(dockSlot.children.length, 0);
+  assert.equal(bar._activityDockState, null);
+  assert.equal(dockSlot.style.display, 'none');
+});
+
+test('dockActivityButton prunes duplicate activity nodes already left in the dock slot', () => {
+  const api = buildHarness();
+  const buttonRow = new MockNode('buttonRow');
+  const dockSlot = new MockNode('dockSlot');
+  const currentNode = new MockNode('currentNode');
+  const staleNode = new MockNode('staleNode');
+  const bar = {
+    _buttonRow: buttonRow,
+    _activityDockSlot: dockSlot,
+    _activityDockState: {
+      node: currentNode,
+      originalParent: null,
+      originalNextSibling: null,
+      nativeContainer: null,
+      nativeDisplay: '',
+      nodeMarginLeft: '',
+      nodeMarginRight: '',
+    },
+  };
+  buttonRow.appendChild(dockSlot);
+  dockSlot.appendChild(staleNode);
+  dockSlot.appendChild(currentNode);
+  connectTree(buttonRow);
+
+  api.dockActivityButton(bar);
+
+  assert.deepEqual(dockSlot.children.map((node) => node.name), ['currentNode']);
+  assert.equal(dockSlot.style.display, 'flex');
+});


### PR DESCRIPTION
## Summary

This fixes a UI bug where the docked `Activity` pill could duplicate, and sometimes continue multiplying, while scrolling on Sora profile/feed pages.

The root cause was the Activity docking logic keeping stale docked nodes around when Sora remounted the native header controls. On the next docking pass, a fresh Activity node could be added without removing the old one.

## What changed

- added dock-slot cleanup for Activity docking
- remove stale docked Activity nodes when their original parent is no longer connected
- prune duplicate Activity nodes already present in the dock slot before reusing the current one
- added regression tests covering both stale-node cleanup and duplicate pruning

## Files changed

- `inject.js`
- `tests/inject-activity-docking.regression.test.js`

## Why this fixes it

The custom control bar now treats the Activity dock slot as a single-owner container:
- undocking clears any stale docked children
- redocking clears leftover duplicates before showing or reusing the active node

That prevents orphaned Activity pills from accumulating across React remounts and scroll-driven rerenders.

## Verification

- `for f in *.js tests/*.js; do node --check "$f"; done`
- `node --test tests/*.test.js`

## Risk / notes

- Low risk and tightly scoped to Activity docking behavior
- Regression coverage is included for the two observed failure modes
- A quick browser sanity check on a profile page with repeated scrolling is still recommended before merge
