### PR TITLE
feat: highlight creator tools redo buttons for remix drafts

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -1332,6 +1332,35 @@
     return downloadBtn;
   }
 
+  function extractDraftRemixTargetId(item) {
+    const candidates = [
+      item?.creation_config?.remix_target_post?.post?.id,
+      item?.creation_config?.remix_target_post?.id,
+      item?.remix_target_post_id,
+    ];
+    for (const candidate of candidates) {
+      const value = typeof candidate === 'string' ? candidate.trim() : '';
+      if (value) return value;
+    }
+    return null;
+  }
+
+  function applyDraftRemixTargetMetadata(draftId, item) {
+    const remixTargetId = extractDraftRemixTargetId(item);
+    if (!remixTargetId) return null;
+    if (/^gen_/i.test(remixTargetId)) {
+      idToRemixTargetDraft.set(draftId, remixTargetId);
+    } else {
+      idToRemixTarget.set(draftId, remixTargetId);
+    }
+    return remixTargetId;
+  }
+
+  function isDraftRemix(draftId) {
+    if (!draftId) return false;
+    return idToRemixTarget.has(draftId) || idToRemixTargetDraft.has(draftId);
+  }
+
   function ensureRedoButton(draftCard, draftId) {
     if (!draftId) return null;
 
@@ -1373,12 +1402,12 @@
 
       redoBtn.addEventListener('mouseenter', () => {
         if (!redoBtn.disabled) {
-          redoBtn.style.background = 'rgba(0,0,0,0.9)';
+          redoBtn.style.background = isDraftRemix(draftId) ? 'rgba(37,99,235,0.96)' : 'rgba(0,0,0,0.9)';
           redoBtn.style.transform = 'scale(1.05)';
         }
       });
       redoBtn.addEventListener('mouseleave', () => {
-        redoBtn.style.background = 'rgba(0,0,0,0.75)';
+        redoBtn.style.background = isDraftRemix(draftId) ? 'rgba(59,130,246,0.85)' : 'rgba(0,0,0,0.75)';
         redoBtn.style.transform = 'scale(1)';
       });
 
@@ -1435,9 +1464,14 @@
 
     // Update button state based on whether prompt exists
     const hasPrompt = idToPrompt.has(draftId);
+    const remixDraft = isDraftRemix(draftId);
     redoBtn.disabled = !hasPrompt;
     redoBtn.style.opacity = hasPrompt ? '1' : '0.4';
     redoBtn.style.cursor = hasPrompt ? 'pointer' : 'not-allowed';
+    redoBtn.style.background = remixDraft ? 'rgba(59,130,246,0.85)' : 'rgba(0,0,0,0.75)';
+    redoBtn.style.boxShadow = remixDraft ? '0 0 0 1px rgba(255,255,255,0.12) inset' : 'none';
+    redoBtn.title = remixDraft ? 'Redo from remix source' : 'Redo generation';
+    redoBtn.setAttribute('aria-label', remixDraft ? 'Redo generation (this draft is a remix)' : 'Redo generation');
 
     return redoBtn;
   }
@@ -1507,6 +1541,10 @@
       draftCard.appendChild(remixBtn);
     }
 
+    remixBtn.style.background = 'rgba(0,0,0,0.75)';
+    remixBtn.style.boxShadow = 'none';
+    remixBtn.title = 'Remix this draft';
+    remixBtn.setAttribute('aria-label', 'Remix this draft');
     return remixBtn;
   }
 
@@ -1904,16 +1942,17 @@ function badgeEmojiFor(id, meta) {
     }
 
     for (const draftCard of draftCards) {
-      // Skip if we've already processed this card
-      if (processedDraftCards.has(draftCard)) continue;
-
       const draftId = extractDraftIdFromCard(draftCard);
       if (!draftId) continue;
+
+      ensureRedoButton(draftCard, draftId);
+
+      // Skip if we've already processed this card
+      if (processedDraftCards.has(draftCard)) continue;
 
       ensureDurationBadge(draftCard, draftId);
       ensureCopyPromptButton(draftCard, draftId);
       ensureDownloadButton(draftCard, draftId);
-      ensureRedoButton(draftCard, draftId);
       ensureRemixButton(draftCard, draftId);
       processedDraftCards.add(draftCard);
       processedDraftCardsCount++; // Increment count for early exit optimization
@@ -6314,10 +6353,7 @@ async function renderAnalyzeTable(force = false) {
         }
 
         // Extract remix target post ID if this is a remix of a post
-        const remixTargetPostId = item?.creation_config?.remix_target_post?.post?.id;
-        if (remixTargetPostId && typeof remixTargetPostId === 'string') {
-          idToRemixTarget.set(draftId, remixTargetPostId);
-        }
+        applyDraftRemixTargetMetadata(draftId, item);
 
         // Check if this draft is a remix of another draft (only if not already mapped)
         if (!idToRemixTargetDraft.has(draftId)) {

--- a/tests/inject-draft-remix-indicator.regression.test.js
+++ b/tests/inject-draft-remix-indicator.regression.test.js
@@ -1,0 +1,199 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const INJECT_PATH = path.join(__dirname, '..', 'inject.js');
+
+function buildHarness() {
+  const src = fs.readFileSync(INJECT_PATH, 'utf8');
+  const start = src.indexOf('  function extractDraftRemixTargetId(item) {');
+  assert.notEqual(start, -1, 'draft remix snippet start not found');
+  const end = src.indexOf('  // Check for pending redo prompt on page load (for remix navigation)', start);
+  assert.notEqual(end, -1, 'draft remix snippet end not found');
+  const snippet = src.slice(start, end);
+
+  const context = {};
+  const bootstrap = `
+    const DRAFT_BUTTON_SIZE = 24;
+    const DRAFT_BUTTON_MARGIN = 6;
+    const DRAFT_BUTTON_SPACING = 4;
+    const idToRemixTarget = new Map();
+    const idToRemixTargetDraft = new Map();
+    const idToPrompt = new Map();
+
+    class FakeNode {
+      constructor(tagName) {
+        this.tagName = tagName;
+        this.className = '';
+        this.children = [];
+        this.style = {};
+        this.attributes = {};
+        this.parentNode = null;
+        this.innerHTML = '';
+        this.title = '';
+        this.listeners = new Map();
+      }
+
+      appendChild(child) {
+        this.children.push(child);
+        child.parentNode = this;
+        return child;
+      }
+
+      querySelector(selector) {
+        if (!selector.startsWith('.')) return null;
+        const className = selector.slice(1);
+        const stack = [...this.children];
+        while (stack.length) {
+          const node = stack.shift();
+          if ((node.className || '').split(/\\s+/).includes(className)) return node;
+          stack.push(...(node.children || []));
+        }
+        return null;
+      }
+
+      setAttribute(name, value) {
+        this.attributes[name] = String(value);
+      }
+
+      getAttribute(name) {
+        return Object.prototype.hasOwnProperty.call(this.attributes, name) ? this.attributes[name] : null;
+      }
+
+      addEventListener(type, handler) {
+        this.listeners.set(type, handler);
+      }
+    }
+
+    const document = {
+      createElement(tagName) {
+        return new FakeNode(tagName);
+      },
+    };
+
+    const sessionStorage = {
+      setItem() {},
+    };
+
+    const window = {
+      location: { href: '' },
+    };
+
+    function getComputedStyle() {
+      return { position: 'relative' };
+    }
+
+${snippet}
+
+    function reset() {
+      idToRemixTarget.clear();
+      idToRemixTargetDraft.clear();
+      idToPrompt.clear();
+    }
+
+    globalThis.__draftRemixApi = {
+      reset,
+      FakeNode,
+      extractDraftRemixTargetId,
+      applyDraftRemixTargetMetadata,
+      isDraftRemix,
+      ensureRedoButton,
+      getPostTarget: (draftId) => idToRemixTarget.get(draftId) || null,
+      getDraftTarget: (draftId) => idToRemixTargetDraft.get(draftId) || null,
+      setPrompt: (draftId, prompt) => idToPrompt.set(draftId, prompt),
+    };
+  `;
+
+  vm.createContext(context);
+  vm.runInContext(bootstrap, context, { filename: 'inject-draft-remix-indicator-harness.js' });
+  return context.__draftRemixApi;
+}
+
+test('extractDraftRemixTargetId supports nested post ids, direct target ids, and fallback post ids', () => {
+  const api = buildHarness();
+
+  assert.equal(
+    api.extractDraftRemixTargetId({
+      creation_config: {
+        remix_target_post: {
+          post: { id: 's_parent_123' },
+        },
+      },
+    }),
+    's_parent_123'
+  );
+
+  assert.equal(
+    api.extractDraftRemixTargetId({
+      creation_config: {
+        remix_target_post: { id: 'gen_parent_456' },
+      },
+    }),
+    'gen_parent_456'
+  );
+
+  assert.equal(
+    api.extractDraftRemixTargetId({ remix_target_post_id: 's_parent_789' }),
+    's_parent_789'
+  );
+
+  assert.equal(api.extractDraftRemixTargetId({ creation_config: { remix_target_post: null } }), null);
+});
+
+test('applyDraftRemixTargetMetadata routes post and draft remix targets into the correct maps', () => {
+  const api = buildHarness();
+  api.reset();
+
+  assert.equal(
+    api.applyDraftRemixTargetMetadata('gen_draft_post', {
+      creation_config: {
+        remix_target_post: {
+          post: { id: 's_parent_post' },
+        },
+      },
+    }),
+    's_parent_post'
+  );
+  assert.equal(api.getPostTarget('gen_draft_post'), 's_parent_post');
+  assert.equal(api.isDraftRemix('gen_draft_post'), true);
+
+  assert.equal(
+    api.applyDraftRemixTargetMetadata('gen_draft_draft', {
+      creation_config: {
+        remix_target_post: { id: 'gen_parent_draft' },
+      },
+    }),
+    'gen_parent_draft'
+  );
+  assert.equal(api.getDraftTarget('gen_draft_draft'), 'gen_parent_draft');
+  assert.equal(api.isDraftRemix('gen_draft_draft'), true);
+});
+
+test('ensureRedoButton turns blue when remix metadata arrives after the card was already rendered', () => {
+  const api = buildHarness();
+  api.reset();
+
+  const draftCard = new api.FakeNode('div');
+  api.setPrompt('gen_late_remix', 'retro hedgehog oracle');
+
+  const redoButton = api.ensureRedoButton(draftCard, 'gen_late_remix');
+  assert.equal(redoButton.style.background, 'rgba(0,0,0,0.75)');
+  assert.equal(redoButton.title, 'Redo generation');
+
+  api.applyDraftRemixTargetMetadata('gen_late_remix', {
+    creation_config: {
+      remix_target_post: {
+        post: { id: 's_parent_late' },
+      },
+    },
+  });
+
+  const updatedButton = api.ensureRedoButton(draftCard, 'gen_late_remix');
+  assert.equal(updatedButton, redoButton);
+  assert.equal(updatedButton.style.background, 'rgba(59,130,246,0.85)');
+  assert.equal(updatedButton.style.boxShadow, '0 0 0 1px rgba(255,255,255,0.12) inset');
+  assert.equal(updatedButton.title, 'Redo from remix source');
+  assert.equal(updatedButton.getAttribute('aria-label'), 'Redo generation (this draft is a remix)');
+});

--- a/tests/uv-drafts-page.regression.test.js
+++ b/tests/uv-drafts-page.regression.test.js
@@ -13,6 +13,7 @@ const {
   resolveDraftPostData,
   applyPublishedPostToDraftData,
   extractRemixTargetPostId,
+  applyRetryButtonRemixTone,
   extractPublishedPostGenerationId,
   buildComposerSourceFromPublishedPost,
   isLargeComposerSizeAllowed,
@@ -193,6 +194,16 @@ test('extractRemixTargetPostId prefers nested published remix targets from draft
   assert.equal(extractRemixTargetPostId(apiDraft), 's_parent_123');
   assert.equal(extractRemixTargetPostId({}, { remix_target_post_id: 's_existing_456' }), 's_existing_456');
   assert.equal(extractRemixTargetPostId({ creation_config: { remix_target_post: { id: 'gen_parent_789' } } }), 'gen_parent_789');
+});
+
+test('applyRetryButtonRemixTone highlights creator tools redo buttons only for remix drafts', () => {
+  const button = { dataset: {} };
+
+  applyRetryButtonRemixTone(button, true);
+  assert.equal(button.dataset.tone, 'info');
+
+  applyRetryButtonRemixTone(button, false);
+  assert.equal('tone' in button.dataset, false);
 });
 
 test('buildComposerSourceFromPublishedPost preserves post media and any embedded generation ID', () => {

--- a/uv-drafts-page.js
+++ b/uv-drafts-page.js
@@ -435,6 +435,16 @@
     return null;
   }
 
+  function applyRetryButtonRemixTone(button, isRemixDraft) {
+    if (!button || !button.dataset) return button;
+    if (isRemixDraft) {
+      button.dataset.tone = 'info';
+      return button;
+    }
+    delete button.dataset.tone;
+    return button;
+  }
+
   function extractPublishedPostGenerationId(post) {
     const candidates = [
       post?.generation_id,
@@ -5813,11 +5823,10 @@
     copyBtn.disabled = !String(draft.prompt || '').trim();
     actionsRow.appendChild(copyBtn);
 
+    const isRemixDraft = !!String(draft?.remix_target_draft_id || draft?.remix_target_post_id || '').trim();
     const retryBtn = createActionBtn(icons.retry, 'Retry (copy prompt to composer)', async () => {
       const prompt = String(draft.prompt || '').trim();
       if (!prompt) return;
-
-      const isRemixDraft = !!String(draft?.remix_target_draft_id || draft?.remix_target_post_id || '').trim();
       let source = null;
       let sourceError = '';
       if (isRemixDraft) {
@@ -5861,6 +5870,7 @@
       }
       flashIconSuccess(retryBtn, icons.retry);
     });
+    applyRetryButtonRemixTone(retryBtn, isRemixDraft);
     retryBtn.disabled = !String(draft.prompt || '').trim();
     actionsRow.appendChild(retryBtn);
 
@@ -7119,6 +7129,8 @@
       .uvd-actions-row2 { display:grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap:6px; padding: 0 10px 10px; }
       .uvd-icon-btn { width: 100%; height: 34px; border-radius: 9px; border: 1px solid var(--uvd-border); background: var(--uvd-surface); color: var(--uvd-text); display:flex; align-items:center; justify-content:center; cursor:pointer; transition: background .15s ease, border-color .15s ease, color .15s ease, opacity .15s ease; }
       .uvd-icon-btn:hover:not(:disabled) { background: var(--uvd-surface-hover); border-color: var(--uvd-border-strong); }
+      .uvd-icon-btn[data-tone="info"] { background: rgba(59,130,246,0.85); border-color: rgba(59,130,246,0.92); color: #fff; box-shadow: 0 0 0 1px rgba(255,255,255,0.12) inset; }
+      .uvd-icon-btn[data-tone="info"]:hover:not(:disabled) { background: rgba(37,99,235,0.96); border-color: rgba(37,99,235,0.96); }
       .uvd-icon-btn:disabled { opacity: .42; cursor:not-allowed; color: var(--uvd-text-dim); background: rgba(255,255,255,0.04); border-color: rgba(255,255,255,0.08); pointer-events: none; }
       .uvd-action-pill { width: 100%; min-height: 38px; border: 1px solid var(--uvd-border); background: var(--uvd-surface); border-radius: 9px; color: var(--uvd-text); font-size: 13px; font-weight: 600; cursor:pointer; transition: background .15s ease, border-color .15s ease, color .15s ease, opacity .15s ease; }
       .uvd-action-pill:hover:not(:disabled) { background: var(--uvd-surface-hover); border-color: var(--uvd-border-strong); }
@@ -7499,6 +7511,7 @@
       resolveDraftPostData,
       applyPublishedPostToDraftData,
       extractRemixTargetPostId,
+      applyRetryButtonRemixTone,
       extractPublishedPostGenerationId,
       buildComposerSourceFromPublishedPost,
       isLargeComposerSizeAllowed,


### PR DESCRIPTION
## Summary

This adds a consistent remix indicator for drafts across both draft surfaces by reusing the existing redo button instead of adding more card chrome.

If a draft is a remix:
- on the native Sora `/drafts` page, the Creator Tools redo button is highlighted blue
- on `/creatortools`, the Creator Tools retry/redo button is highlighted blue

Original drafts keep the default neutral redo button styling.

## What changed

- detect remix drafts from existing remix target metadata
- highlight the existing redo button for remix drafts instead of adding a separate badge
- keep the native drafts and Creator Tools treatments visually consistent
- add regression coverage for both implementations

## Files changed

- `/Users/nicholaslouie/dev/sora-creator-tools/inject.js`
- `/Users/nicholaslouie/dev/sora-creator-tools/uv-drafts-page.js`
- `/Users/nicholaslouie/dev/sora-creator-tools/tests/inject-draft-remix-indicator.regression.test.js`
- `/Users/nicholaslouie/dev/sora-creator-tools/tests/uv-drafts-page.regression.test.js`

## Details

### Native drafts (`/drafts`)
- broadened remix detection so it works for both nested published-post remix targets and direct draft-generation remix targets
- updated the existing redo button so remix drafts render with a blue highlighted state
- kept the button reactive when remix metadata arrives after the card has already rendered

### Creator Tools (`/creatortools`)
- apply the same remix-aware blue highlight to the existing retry/redo button
- reuse the existing `remix_target_draft_id` / `remix_target_post_id` metadata already stored for drafts
- keep original drafts on the default neutral button style

## Why

This makes remix drafts easy to spot at a glance without adding another icon or badge to already busy draft cards. It also keeps the signal attached to the action that actually behaves differently for remix drafts.

## Verification

- `for f in *.js tests/*.js; do node --check "$f"; done`
- `node --test tests/*.test.js`
- `git diff --check`

## Notes

- this is intentionally scoped to visual remix indication only
- no new permissions or external network calls were added
- regression coverage includes both the native drafts flow and the Creator Tools flow

<img width="1508" height="908" alt="Screenshot 2026-03-15 at 5 47 39 PM" src="https://github.com/user-attachments/assets/bf44135b-4861-40dc-8d42-be4c68f2a510" />
<img width="1508" height="903" alt="Screenshot 2026-03-15 at 5 47 27 PM" src="https://github.com/user-attachments/assets/ab850806-be15-4461-8387-b4a853a56bd6" />

