### PR TITLE
Add Followers & Following cleanup workspace to the dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .examples/
 .claude/
 /dist/
+/.playwright-cli/
+/output/
+/release.zip

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Unofficial community extension. Not affiliated with, endorsed by, or sponsored b
 - Adds feed controls including filtering, Gather mode, and Analyze mode on Top feed.
 - Captures metrics snapshots locally while you browse.
 - Provides a full dashboard (`dashboard.html`) with charts, compare mode, post filters, import/export, and data purge tools.
+- Adds a Followers & Following cleanup workspace in the dashboard that harvests relationship data, highlights non-mutual or low-signal accounts, and can bulk unfollow selected following accounts through Sora's native UI.
 - Adds a dedicated `/uv-drafts` page with:
   - Draft caching and progressive sync
   - Pending task polling
@@ -60,6 +61,7 @@ Unofficial community extension. Not affiliated with, endorsed by, or sponsored b
   - Compare-mode aggregate charts across selected creators
 - Linear + stacked chart modes with adjustable time windows.
 - Compare mode with multi-user pills and aggregate totals.
+- Followers & Following cleanup workspace that captures relationship graphs from Sora profile modals, surfaces non-mutual/zero-signal accounts for review, and can run guided bulk unfollow actions with the native Following buttons.
 - CSV import/export and data cleanup actions from the dashboard data menu.
 
 ### UV Drafts (`/uv-drafts`)
@@ -159,11 +161,11 @@ rm -f release.zip && zip -r release.zip manifest.json *.js *.html *.css icons im
 
 Current repository test suite (Node built-in test runner):
 
-- `87` tests
-- `87` passing
+- `159` tests
+- `159` passing
 - `0` failing
 
-Primary coverage currently targets dashboard regressions and shared UV drafts logic.
+Primary coverage currently targets dashboard regressions, relationship-graph cleanup flows, and shared UV drafts logic.
 
 ## Project Layout
 

--- a/background.js
+++ b/background.js
@@ -82,6 +82,90 @@ function sanitizeCameoUsernames(value) {
   return out;
 }
 
+function sanitizeBoolean(value) {
+  return typeof value === 'boolean' ? value : null;
+}
+
+function sanitizeRelationshipListKind(value) {
+  const s = sanitizeString(value, 16);
+  if (!s) return null;
+  const normalized = s.toLowerCase();
+  return normalized === 'followers' || normalized === 'following' ? normalized : null;
+}
+
+function sanitizeSocialGraphNode(raw) {
+  if (!isPlainObject(raw)) return null;
+  const item = {};
+  const userKey = sanitizeIdToken(raw.user_key);
+  if (userKey) item.user_key = userKey;
+  const userHandle = sanitizeString(raw.user_handle, 80);
+  if (userHandle) item.user_handle = userHandle;
+  const userId = sanitizeUserId(raw.user_id);
+  if (userId != null) item.user_id = userId;
+  if (!item.user_key && userHandle) item.user_key = `h:${userHandle.toLowerCase()}`;
+  if (!item.user_key && userId != null) item.user_key = `id:${String(userId)}`;
+  if (!item.user_key) return null;
+
+  const displayName = sanitizeString(raw.display_name, 120);
+  if (displayName) item.display_name = displayName;
+  const followerCount = sanitizeNumber(raw.follower_count, 0);
+  if (followerCount != null) item.follower_count = followerCount;
+  const followingCount = sanitizeNumber(raw.following_count, 0);
+  if (followingCount != null) item.following_count = followingCount;
+  const postCount = sanitizeNumber(raw.post_count, 0);
+  if (postCount != null) item.post_count = postCount;
+  const replyCount = sanitizeNumber(raw.reply_count, 0);
+  if (replyCount != null) item.reply_count = replyCount;
+  const likesReceivedCount = sanitizeNumber(raw.likes_received_count, 0);
+  if (likesReceivedCount != null) item.likes_received_count = likesReceivedCount;
+  const remixCount = sanitizeNumber(raw.remix_count, 0);
+  if (remixCount != null) item.remix_count = remixCount;
+  const cameoCount = sanitizeNumber(raw.cameo_count, 0);
+  if (cameoCount != null) item.cameo_count = cameoCount;
+  const verified = sanitizeBoolean(raw.verified);
+  if (verified != null) item.verified = verified;
+  const canCameo = sanitizeBoolean(raw.can_cameo);
+  if (canCameo != null) item.can_cameo = canCameo;
+  const followsYou = sanitizeBoolean(raw.follows_you);
+  if (followsYou != null) item.follows_you = followsYou;
+  const isFollowing = sanitizeBoolean(raw.is_following);
+  if (isFollowing != null) item.is_following = isFollowing;
+
+  const planType = sanitizeString(raw.plan_type, 64);
+  if (planType) item.plan_type = planType;
+  const permalink = sanitizeString(raw.permalink, 2048);
+  if (permalink) item.permalink = permalink;
+  const description = sanitizeString(raw.description, 512);
+  if (description) item.description = description;
+  const location = sanitizeString(raw.location, 160);
+  if (location) item.location = location;
+  const createdAt = sanitizeNumber(raw.created_at, 0);
+  if (createdAt != null) item.created_at = createdAt;
+  const updatedAt = sanitizeNumber(raw.updated_at, 0);
+  if (updatedAt != null) item.updated_at = updatedAt;
+  return item;
+}
+
+function sanitizeSocialGraphPayload(raw) {
+  if (!isPlainObject(raw)) return null;
+  const listKind = sanitizeRelationshipListKind(raw.list_kind);
+  if (!listKind) return null;
+  const items = Array.isArray(raw.items) ? raw.items : [];
+  const outItems = [];
+  const limit = Math.min(items.length, 5000);
+  for (let i = 0; i < limit; i++) {
+    const item = sanitizeSocialGraphNode(items[i]);
+    if (item) outItems.push(item);
+  }
+  const replace = raw.replace === true;
+  if (!outItems.length && !replace) return null;
+  const out = { list_kind: listKind, items: outItems };
+  const cursor = sanitizeString(raw.cursor, 2048);
+  if (cursor) out.cursor = cursor;
+  if (replace) out.replace = true;
+  return out;
+}
+
 function sanitizeMetricsSnapshot(raw) {
   if (!isPlainObject(raw)) return null;
   const snap = {};
@@ -143,6 +227,8 @@ function sanitizeMetricsSnapshot(raw) {
   if (followers != null) snap.followers = followers;
   const cameoCount = sanitizeNumber(raw.cameo_count, 0);
   if (cameoCount != null) snap.cameo_count = cameoCount;
+  const socialGraph = sanitizeSocialGraphPayload(raw.social_graph);
+  if (socialGraph) snap.social_graph = socialGraph;
   const duration = sanitizeNumber(raw.duration, 0, 60 * 60 * 10);
   if (duration != null) snap.duration = duration;
   const width = sanitizeNumber(raw.width, 1, 20000);
@@ -150,7 +236,7 @@ function sanitizeMetricsSnapshot(raw) {
   const height = sanitizeNumber(raw.height, 1, 20000);
   if (height != null) snap.height = height;
 
-  const hasSignal = !!snap.postId || snap.followers != null || snap.cameo_count != null;
+  const hasSignal = !!snap.postId || snap.followers != null || snap.cameo_count != null || !!snap.social_graph;
   return hasSignal ? snap : null;
 }
 
@@ -199,6 +285,43 @@ function sanitizeMetricsRequest(message) {
   };
 }
 
+function sanitizeCleanupTarget(raw) {
+  if (!isPlainObject(raw)) return null;
+  const userKey = sanitizeIdToken(raw.userKey ?? raw.user_key);
+  const userHandle = sanitizeString(raw.userHandle ?? raw.user_handle, 80);
+  const permalink = sanitizeString(raw.permalink, 2048);
+  if (!userKey && !userHandle) return null;
+  return {
+    userKey: userKey || (userHandle ? `h:${userHandle.toLowerCase()}` : null),
+    userHandle: userHandle || null,
+    permalink: permalink || null,
+  };
+}
+
+function sanitizeCleanupRequestId(value) {
+  return sanitizeString(value, 160);
+}
+
+function sanitizeCleanupBulkUnfollowRequest(message) {
+  const requestId = sanitizeCleanupRequestId(message?.requestId);
+  const profileHandle = sanitizeString(message?.profileHandle, 80);
+  const userKey = sanitizeIdToken(message?.userKey);
+  if (!Array.isArray(message?.targets)) return null;
+  const targets = [];
+  for (const raw of message.targets) {
+    if (targets.length >= 150) break;
+    const item = sanitizeCleanupTarget(raw);
+    if (item) targets.push(item);
+  }
+  if (!targets.length) return null;
+  return {
+    requestId: requestId || `cleanup:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
+    profileHandle: profileHandle || null,
+    userKey: userKey || null,
+    targets,
+  };
+}
+
 function isTrustedSender(sender) {
   if (!sender) return false;
   const tabUrl = String(sender.tab?.url || '');
@@ -211,6 +334,124 @@ function isTrustedSender(sender) {
 function trimSeriesInPlace(arr, maxPoints = MAX_PROFILE_SERIES_POINTS) {
   if (!Array.isArray(arr) || arr.length <= maxPoints) return;
   arr.splice(0, arr.length - maxPoints);
+}
+
+function resolveMetricsUserKey(metrics, preferredKey, userHandle, userId) {
+  const users = metrics?.users || {};
+  if (preferredKey && users[preferredKey]) return preferredKey;
+  const handle = typeof userHandle === 'string' ? userHandle.trim().toLowerCase() : '';
+  const id = userId != null ? String(userId) : '';
+  if (handle) {
+    const byHandleKey = `h:${handle}`;
+    if (users[byHandleKey]) return byHandleKey;
+  }
+  if (id) {
+    for (const [key, user] of Object.entries(users)) {
+      if (user?.id != null && String(user.id) === id) return key;
+      if (typeof key === 'string' && key.startsWith('id:') && key.slice(3) === id) return key;
+    }
+  }
+  if (handle) {
+    for (const [key, user] of Object.entries(users)) {
+      const candidateHandle = String(user?.handle || user?.userHandle || (typeof key === 'string' && key.startsWith('h:') ? key.slice(2) : '') || '').trim().toLowerCase();
+      if (candidateHandle && candidateHandle === handle) return key;
+    }
+  }
+  if (preferredKey) return preferredKey;
+  if (handle) return `h:${handle}`;
+  if (id) return `id:${id}`;
+  return 'unknown';
+}
+
+function ensureRelationshipGraph(userEntry) {
+  if (!isPlainObject(userEntry.relationshipGraph)) userEntry.relationshipGraph = {};
+  const graph = userEntry.relationshipGraph;
+  if (!isPlainObject(graph.nodes)) graph.nodes = {};
+  if (!isPlainObject(graph.edges)) graph.edges = {};
+  if (!isPlainObject(graph.edges.followers)) graph.edges.followers = {};
+  if (!isPlainObject(graph.edges.following)) graph.edges.following = {};
+  if (!isPlainObject(graph.fullSyncAt)) graph.fullSyncAt = {};
+  return graph;
+}
+
+function upsertRelationshipGraph(userEntry, graphPayload, seenAt) {
+  if (!userEntry || !graphPayload) return false;
+  const listKind = graphPayload.list_kind === 'following' ? 'following' : (graphPayload.list_kind === 'followers' ? 'followers' : null);
+  if (!listKind) return false;
+  const graph = ensureRelationshipGraph(userEntry);
+  const replace = graphPayload.replace === true;
+  const edgeBucket = isPlainObject(graph.edges[listKind]) ? graph.edges[listKind] : {};
+  const nextEdgeBucket = replace ? {} : edgeBucket;
+  let changed = false;
+  for (const rawNode of Array.isArray(graphPayload.items) ? graphPayload.items : []) {
+    if (!rawNode || typeof rawNode !== 'object') continue;
+    const targetKey = rawNode.user_key || (rawNode.user_id != null ? `id:${String(rawNode.user_id)}` : null);
+    if (!targetKey) continue;
+    const prevNode = isPlainObject(graph.nodes[targetKey]) ? graph.nodes[targetKey] : null;
+    const nextNode = {
+      ...(prevNode || {}),
+      user_key: targetKey,
+      user_handle: rawNode.user_handle || prevNode?.user_handle || null,
+      user_id: rawNode.user_id != null ? String(rawNode.user_id) : (prevNode?.user_id != null ? String(prevNode.user_id) : null),
+      display_name: rawNode.display_name || prevNode?.display_name || null,
+      plan_type: rawNode.plan_type || prevNode?.plan_type || null,
+      permalink: rawNode.permalink || prevNode?.permalink || null,
+      description: rawNode.description || prevNode?.description || null,
+      location: rawNode.location || prevNode?.location || null,
+      firstSeenAt: prevNode?.firstSeenAt || seenAt,
+      lastSeenAt: seenAt,
+    };
+    const numericFields = ['follower_count', 'following_count', 'post_count', 'reply_count', 'likes_received_count', 'remix_count', 'cameo_count', 'created_at', 'updated_at'];
+    for (const field of numericFields) {
+      const value = Number(rawNode[field]);
+      if (Number.isFinite(value)) nextNode[field] = value;
+      else if (prevNode && prevNode[field] != null) nextNode[field] = prevNode[field];
+    }
+    const booleanFields = ['verified', 'can_cameo', 'follows_you', 'is_following'];
+    for (const field of booleanFields) {
+      if (typeof rawNode[field] === 'boolean') nextNode[field] = rawNode[field];
+      else if (prevNode && typeof prevNode[field] === 'boolean') nextNode[field] = prevNode[field];
+    }
+    if (JSON.stringify(prevNode || null) !== JSON.stringify(nextNode)) {
+      graph.nodes[targetKey] = nextNode;
+      changed = true;
+    }
+
+    const prevEdge = isPlainObject(edgeBucket[targetKey]) ? edgeBucket[targetKey] : null;
+    const nextEdge = {
+      ...(prevEdge || {}),
+      user_key: targetKey,
+      user_handle: nextNode.user_handle || prevEdge?.user_handle || null,
+      user_id: nextNode.user_id || prevEdge?.user_id || null,
+      seenAt,
+      follows_you: typeof rawNode.follows_you === 'boolean'
+        ? rawNode.follows_you
+        : (typeof prevEdge?.follows_you === 'boolean' ? prevEdge.follows_you : listKind === 'followers'),
+      is_following: typeof rawNode.is_following === 'boolean'
+        ? rawNode.is_following
+        : (typeof prevEdge?.is_following === 'boolean' ? prevEdge.is_following : listKind === 'following'),
+    };
+    if (JSON.stringify(prevEdge || null) !== JSON.stringify(nextEdge)) changed = true;
+    nextEdgeBucket[targetKey] = nextEdge;
+  }
+  if (replace) {
+    if (JSON.stringify(edgeBucket) !== JSON.stringify(nextEdgeBucket)) {
+      graph.edges[listKind] = nextEdgeBucket;
+      changed = true;
+    }
+    if (graph.fullSyncAt[listKind] !== seenAt) {
+      graph.fullSyncAt[listKind] = seenAt;
+      changed = true;
+    }
+  } else if (nextEdgeBucket !== edgeBucket) {
+    graph.edges[listKind] = nextEdgeBucket;
+    changed = true;
+  }
+  if (graph.updatedAt !== seenAt) {
+    graph.updatedAt = seenAt;
+    changed = true;
+  }
+  return changed;
 }
 
 function normalizeMetrics(raw) {
@@ -526,13 +767,27 @@ async function flush() {
       let dirty = false;
       const touchedPosts = new Set();
       for (const snap of items) {
-        const userKey = snap.userKey || snap.pageUserKey || 'unknown';
+        const preferredUserKey = snap.userKey || snap.pageUserKey || 'unknown';
+        const userKey = snap.social_graph
+          ? resolveMetricsUserKey(metrics, preferredUserKey, snap.userHandle || snap.pageUserHandle, snap.userId)
+          : preferredUserKey;
         if (!metrics.users[userKey]) {
           dirty = true;
         }
         const userEntry = metrics.users[userKey] || (metrics.users[userKey] = { handle: snap.userHandle || snap.pageUserHandle || null, id: snap.userId || null, posts: {}, followers: [], cameos: [] });
         if (!userEntry.posts || typeof userEntry.posts !== 'object' || Array.isArray(userEntry.posts)) userEntry.posts = {};
         if (!Array.isArray(userEntry.followers)) userEntry.followers = [];
+        if ((typeof userEntry.handle !== 'string' || !userEntry.handle) && (snap.userHandle || snap.pageUserHandle)) {
+          userEntry.handle = snap.userHandle || snap.pageUserHandle || null;
+          dirty = true;
+        }
+        if (userEntry.id == null && snap.userId != null) {
+          userEntry.id = snap.userId;
+          dirty = true;
+        }
+        if (snap.social_graph) {
+          if (upsertRelationshipGraph(userEntry, snap.social_graph, snap.ts || Date.now())) dirty = true;
+        }
         if (snap.postId) {
           postIdToUserKey.set(snap.postId, userKey);
           if (!userEntry.posts[snap.postId]) {
@@ -813,6 +1068,204 @@ function openOrFocusDashboard(sendResponse) {
   });
 }
 
+function queryTabs(queryInfo) {
+  return new Promise((resolve) => {
+    try {
+      chrome.tabs.query(queryInfo, (tabs) => resolve(Array.isArray(tabs) ? tabs : []));
+    } catch {
+      resolve([]);
+    }
+  });
+}
+
+function createTab(createProperties) {
+  return new Promise((resolve, reject) => {
+    try {
+      chrome.tabs.create(createProperties, (tab) => {
+        if (chrome.runtime.lastError) {
+          reject(new Error(chrome.runtime.lastError.message || 'Could not open a Sora tab.'));
+          return;
+        }
+        resolve(tab || null);
+      });
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+function updateTab(tabId, updateProperties) {
+  return new Promise((resolve, reject) => {
+    try {
+      chrome.tabs.update(tabId, updateProperties, (tab) => {
+        if (chrome.runtime.lastError) {
+          reject(new Error(chrome.runtime.lastError.message || 'Could not focus the Sora tab.'));
+          return;
+        }
+        resolve(tab || null);
+      });
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+const CLEANUP_SORA_ORIGIN = 'https://sora.chatgpt.com';
+const CLEANUP_TAB_MESSAGE_TIMEOUT_MS = 45000;
+
+function normalizeCleanupProfileHandle(value) {
+  const raw = String(value || '').trim().replace(/^@+/, '');
+  if (!raw) return '';
+  return raw
+    .replace(/^profile\//i, '')
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '')
+    .trim()
+    .toLowerCase();
+}
+
+function buildCleanupProfileUrl(profileHandle) {
+  const normalized = normalizeCleanupProfileHandle(profileHandle);
+  return normalized
+    ? `${CLEANUP_SORA_ORIGIN}/profile/${encodeURIComponent(normalized)}`
+    : `${CLEANUP_SORA_ORIGIN}/profile`;
+}
+
+function getCleanupProfileHandleFromUrl(url) {
+  try {
+    const parsed = new URL(url);
+    if (parsed.origin !== CLEANUP_SORA_ORIGIN) return null;
+    const segments = parsed.pathname.split('/').filter(Boolean);
+    if (segments[0] !== 'profile') return null;
+    if (!segments[1]) return '';
+    return normalizeCleanupProfileHandle(decodeURIComponent(segments[1]));
+  } catch {}
+  return null;
+}
+
+function isCleanupProfileTab(tab, profileHandle) {
+  if (!tab?.url) return false;
+  const targetHandle = normalizeCleanupProfileHandle(profileHandle);
+  const tabHandle = getCleanupProfileHandleFromUrl(tab.url);
+  if (tabHandle == null) return false;
+  return tabHandle === targetHandle;
+}
+
+async function ensureCleanupTabReady(tab, profileHandle) {
+  if (tab?.id == null) throw new Error('Could not focus the Sora cleanup tab.');
+  const targetUrl = buildCleanupProfileUrl(profileHandle);
+  const needsNavigation = !isCleanupProfileTab(tab, profileHandle);
+  const updated = await updateTab(tab.id, needsNavigation ? { active: true, url: targetUrl } : { active: true });
+  if (needsNavigation || (updated?.status !== 'complete' && tab?.status !== 'complete')) {
+    await waitForTabComplete(tab.id);
+  }
+  return updated || tab;
+}
+
+function sendTabMessage(tabId, message, timeoutMs = CLEANUP_TAB_MESSAGE_TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finishResolve = (value) => {
+      if (settled) return;
+      settled = true;
+      try { clearTimeout(timer); } catch {}
+      resolve(value);
+    };
+    const finishReject = (error) => {
+      if (settled) return;
+      settled = true;
+      try { clearTimeout(timer); } catch {}
+      reject(error);
+    };
+    const timer = setTimeout(() => {
+      finishReject(new Error('Timed out waiting for the Sora page to finish the cleanup action.'));
+    }, Math.max(1000, Number(timeoutMs) || 0));
+    try {
+      chrome.tabs.sendMessage(tabId, message, (response) => {
+        if (chrome.runtime.lastError) {
+          finishReject(new Error(chrome.runtime.lastError.message || 'Could not reach the Sora page.'));
+          return;
+        }
+        finishResolve(response);
+      });
+    } catch (err) {
+      finishReject(err);
+    }
+  });
+}
+
+function waitForTabComplete(tabId, timeoutMs = 20000) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      try { chrome.tabs.onUpdated.removeListener(onUpdated); } catch {}
+      reject(new Error('Timed out waiting for the Sora tab to finish loading.'));
+    }, Math.max(1000, Number(timeoutMs) || 0));
+
+    const onUpdated = (updatedTabId, changeInfo) => {
+      if (updatedTabId !== tabId) return;
+      if (changeInfo?.status === 'complete') {
+        clearTimeout(timeout);
+        try { chrome.tabs.onUpdated.removeListener(onUpdated); } catch {}
+        resolve(true);
+      }
+    };
+    try {
+      chrome.tabs.onUpdated.addListener(onUpdated);
+      chrome.tabs.get(tabId, (tab) => {
+        if (chrome.runtime.lastError) return;
+        if (tab?.status === 'complete') {
+          clearTimeout(timeout);
+          try { chrome.tabs.onUpdated.removeListener(onUpdated); } catch {}
+          resolve(true);
+        }
+      });
+    } catch (err) {
+      clearTimeout(timeout);
+      try { chrome.tabs.onUpdated.removeListener(onUpdated); } catch {}
+      reject(err);
+    }
+  });
+}
+
+async function findOrOpenCleanupTab(profileHandle) {
+  const activeSoraTabs = await queryTabs({ active: true, lastFocusedWindow: true, url: `${CLEANUP_SORA_ORIGIN}/*` });
+  const exactActive = activeSoraTabs.find((tab) => isCleanupProfileTab(tab, profileHandle));
+  if (exactActive?.id != null) return ensureCleanupTabReady(exactActive, profileHandle);
+
+  const profileTabs = await queryTabs({ url: `${CLEANUP_SORA_ORIGIN}/profile*` });
+  const exactProfile = profileTabs.find((tab) => isCleanupProfileTab(tab, profileHandle));
+  if (exactProfile?.id != null) return ensureCleanupTabReady(exactProfile, profileHandle);
+
+  const soraTabs = await queryTabs({ url: `${CLEANUP_SORA_ORIGIN}/*` });
+  const exactSora = soraTabs.find((tab) => isCleanupProfileTab(tab, profileHandle));
+  if (exactSora?.id != null) return ensureCleanupTabReady(exactSora, profileHandle);
+
+  const fallbackTab = activeSoraTabs[0] || profileTabs[0] || soraTabs[0] || null;
+  if (fallbackTab?.id != null) return ensureCleanupTabReady(fallbackTab, profileHandle);
+
+  const url = buildCleanupProfileUrl(profileHandle);
+  const created = await createTab({ url, active: true });
+  if (created?.id == null) throw new Error('Could not create a Sora profile tab.');
+  await waitForTabComplete(created.id);
+  return created;
+}
+
+async function dispatchCleanupBulkUnfollow(request) {
+  const tab = await findOrOpenCleanupTab(request.profileHandle);
+  if (tab?.id == null) throw new Error('Could not find a Sora tab for bulk unfollow.');
+  const response = await sendTabMessage(tab.id, {
+    action: 'cleanup_bulk_unfollow',
+    requestId: request.requestId,
+    profileHandle: request.profileHandle,
+    userKey: request.userKey,
+    targets: request.targets,
+  });
+  if (!response || typeof response !== 'object') {
+    throw new Error('No response from the Sora page.');
+  }
+  return response;
+}
+
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (!isPlainObject(message) || typeof message.action !== 'string') return false;
   if (!isTrustedSender(sender)) {
@@ -825,6 +1278,40 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === 'open_dashboard') {
     openOrFocusDashboard(sendResponse);
     return true; // Keep message channel open for async response
+  }
+
+  if (message.action === 'cleanup_bulk_unfollow_result') {
+    const requestId = sanitizeCleanupRequestId(message?.requestId);
+    const payload = isPlainObject(message?.payload)
+      ? message.payload
+      : { ok: false, error: 'No bulk unfollow result payload.' };
+    if (!requestId) return false;
+    if (!sender?.tab?.id) return false;
+    try {
+      chrome.runtime.sendMessage({
+        action: 'cleanup_bulk_unfollow_result',
+        requestId,
+        payload,
+      });
+    } catch {}
+    return false;
+  }
+
+  if (message.action === 'cleanup_bulk_unfollow') {
+    const request = sanitizeCleanupBulkUnfollowRequest(message);
+    if (!request) {
+      sendResponse({ ok: false, error: 'Invalid cleanup unfollow request.' });
+      return false;
+    }
+    (async () => {
+      try {
+        const response = await dispatchCleanupBulkUnfollow(request);
+        sendResponse(response);
+      } catch (err) {
+        sendResponse({ ok: false, error: err?.message || 'Bulk unfollow failed.' });
+      }
+    })();
+    return true;
   }
 
   if (message.action === 'metrics_batch') {

--- a/content.js
+++ b/content.js
@@ -15,6 +15,7 @@
   const MAX_HANDLE_LEN = 80;
   const MAX_REQUEST_ID_LEN = 80;
   const MAX_CAMEO_USERNAMES = 32;
+  const MAX_SOCIAL_GRAPH_ITEMS = 5000;
 
   function sanitizeString(value, maxLen = MAX_STR_LEN) {
     if (typeof value !== 'string') return null;
@@ -51,6 +52,125 @@
       if (!username) continue;
       out.push(username);
     }
+    return out;
+  }
+
+  function sanitizeBoolean(value) {
+    return typeof value === 'boolean' ? value : null;
+  }
+
+  function sanitizeRelationshipListKind(value) {
+    const s = sanitizeString(value, 16);
+    if (!s) return null;
+    const n = s.toLowerCase();
+    return n === 'followers' || n === 'following' ? n : null;
+  }
+
+  function sanitizeCleanupTarget(raw) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+    const userKey = sanitizeIdToken(raw.userKey ?? raw.user_key);
+    const userHandle = sanitizeString(raw.userHandle ?? raw.user_handle, MAX_HANDLE_LEN);
+    const permalink = sanitizeString(raw.permalink, MAX_URL_LEN);
+    if (!userKey && !userHandle) return null;
+    return {
+      userKey: userKey || (userHandle ? `h:${userHandle.toLowerCase()}` : null),
+      userHandle: userHandle || null,
+      permalink: permalink || null,
+    };
+  }
+
+  function sanitizeCleanupBulkUnfollowRequest(message) {
+    const profileHandle = sanitizeString(message?.profileHandle, MAX_HANDLE_LEN);
+    const userKey = sanitizeIdToken(message?.userKey);
+    if (!Array.isArray(message?.targets)) return null;
+    const targets = [];
+    for (const raw of message.targets) {
+      if (targets.length >= 150) break;
+      const item = sanitizeCleanupTarget(raw);
+      if (item) targets.push(item);
+    }
+    if (!targets.length) return null;
+    return {
+      profileHandle: profileHandle || null,
+      userKey: userKey || null,
+      targets,
+    };
+  }
+
+  function sanitizeCleanupRequestId(value) {
+    return sanitizeString(value, 160);
+  }
+
+  function sanitizeSocialGraphNode(raw) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+    const item = {};
+    const userKey = sanitizeIdToken(raw.user_key);
+    if (userKey) item.user_key = userKey;
+    const userHandle = sanitizeString(raw.user_handle, MAX_HANDLE_LEN);
+    if (userHandle) item.user_handle = userHandle;
+    const userId = sanitizeUserId(raw.user_id);
+    if (userId != null) item.user_id = userId;
+    if (!item.user_key && userHandle) item.user_key = `h:${userHandle.toLowerCase()}`;
+    if (!item.user_key && userId != null) item.user_key = `id:${String(userId)}`;
+    if (!item.user_key) return null;
+
+    const displayName = sanitizeString(raw.display_name, 120);
+    if (displayName) item.display_name = displayName;
+    const followerCount = sanitizeNumber(raw.follower_count, 0);
+    if (followerCount != null) item.follower_count = followerCount;
+    const followingCount = sanitizeNumber(raw.following_count, 0);
+    if (followingCount != null) item.following_count = followingCount;
+    const postCount = sanitizeNumber(raw.post_count, 0);
+    if (postCount != null) item.post_count = postCount;
+    const replyCount = sanitizeNumber(raw.reply_count, 0);
+    if (replyCount != null) item.reply_count = replyCount;
+    const likesReceivedCount = sanitizeNumber(raw.likes_received_count, 0);
+    if (likesReceivedCount != null) item.likes_received_count = likesReceivedCount;
+    const remixCount = sanitizeNumber(raw.remix_count, 0);
+    if (remixCount != null) item.remix_count = remixCount;
+    const cameoCount = sanitizeNumber(raw.cameo_count, 0);
+    if (cameoCount != null) item.cameo_count = cameoCount;
+    const verified = sanitizeBoolean(raw.verified);
+    if (verified != null) item.verified = verified;
+    const canCameo = sanitizeBoolean(raw.can_cameo);
+    if (canCameo != null) item.can_cameo = canCameo;
+    const followsYou = sanitizeBoolean(raw.follows_you);
+    if (followsYou != null) item.follows_you = followsYou;
+    const isFollowing = sanitizeBoolean(raw.is_following);
+    if (isFollowing != null) item.is_following = isFollowing;
+
+    const planType = sanitizeString(raw.plan_type, 64);
+    if (planType) item.plan_type = planType;
+    const permalink = sanitizeString(raw.permalink, MAX_URL_LEN);
+    if (permalink) item.permalink = permalink;
+    const description = sanitizeString(raw.description, 512);
+    if (description) item.description = description;
+    const location = sanitizeString(raw.location, 160);
+    if (location) item.location = location;
+    const createdAt = sanitizeNumber(raw.created_at, 0);
+    if (createdAt != null) item.created_at = createdAt;
+    const updatedAt = sanitizeNumber(raw.updated_at, 0);
+    if (updatedAt != null) item.updated_at = updatedAt;
+    return item;
+  }
+
+  function sanitizeSocialGraphPayload(raw) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+    const listKind = sanitizeRelationshipListKind(raw.list_kind);
+    if (!listKind) return null;
+    const items = Array.isArray(raw.items) ? raw.items : [];
+    const outItems = [];
+    const limit = Math.min(items.length, MAX_SOCIAL_GRAPH_ITEMS);
+    for (let i = 0; i < limit; i++) {
+      const item = sanitizeSocialGraphNode(items[i]);
+      if (item) outItems.push(item);
+    }
+    const replace = raw.replace === true;
+    if (!outItems.length && !replace) return null;
+    const out = { list_kind: listKind, items: outItems };
+    const cursor = sanitizeString(raw.cursor, MAX_URL_LEN);
+    if (cursor) out.cursor = cursor;
+    if (replace) out.replace = true;
     return out;
   }
 
@@ -115,6 +235,8 @@
     if (followers != null) item.followers = followers;
     const cameoCount = sanitizeNumber(raw.cameo_count, 0);
     if (cameoCount != null) item.cameo_count = cameoCount;
+    const socialGraph = sanitizeSocialGraphPayload(raw.social_graph);
+    if (socialGraph) item.social_graph = socialGraph;
     const duration = sanitizeNumber(raw.duration, 0, 60 * 60 * 10);
     if (duration != null) item.duration = duration;
     const width = sanitizeNumber(raw.width, 1, 20000);
@@ -122,7 +244,7 @@
     const height = sanitizeNumber(raw.height, 1, 20000);
     if (height != null) item.height = height;
 
-    const hasSignal = !!item.postId || item.followers != null || item.cameo_count != null;
+    const hasSignal = !!item.postId || item.followers != null || item.cameo_count != null || !!item.social_graph;
     return hasSignal ? item : null;
   }
 
@@ -186,8 +308,63 @@
   // Listen for ultra mode changes broadcast from background (avoids chrome.storage.onChanged
   // which would serialize the full metrics blob to every content script on every flush).
   try {
-    chrome.runtime.onMessage.addListener((message) => {
-      if (message?.action === 'ultra_mode_changed') syncUltraModePreference();
+    chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+      if (message?.action === 'ultra_mode_changed') {
+        syncUltraModePreference();
+        return false;
+      }
+      if (message?.action === 'cleanup_bulk_unfollow') {
+        const request = sanitizeCleanupBulkUnfollowRequest(message);
+        const requestId = sanitizeCleanupRequestId(message?.requestId);
+        if (!request) {
+          sendResponse({ ok: false, error: 'Invalid cleanup unfollow payload.' });
+          return false;
+        }
+        if (!requestId) {
+          sendResponse({ ok: false, error: 'Missing cleanup request id.' });
+          return false;
+        }
+        const req = `cleanup:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`;
+        let done = false;
+        const finish = (payload) => {
+          if (done) return;
+          done = true;
+          try { clearTimeout(timer); } catch {}
+          try { window.removeEventListener('message', onReply); } catch {}
+          try {
+            chrome.runtime.sendMessage({
+              action: 'cleanup_bulk_unfollow_result',
+              requestId,
+              payload: payload && typeof payload === 'object' ? payload : { ok: false, error: 'No response from the page action.' },
+            });
+          } catch {}
+        };
+        const onReply = (ev) => {
+          if (ev?.source !== window) return;
+          const data = ev?.data;
+          if (!data || data.__sora_uv__ !== true || data.type !== 'cleanup_action_response' || data.req !== req) return;
+          finish(data.payload || { ok: false, error: 'No cleanup response payload.' });
+        };
+        const timer = setTimeout(() => {
+          finish({ ok: false, error: 'Timed out waiting for the Sora page to process the cleanup action.' });
+        }, 180000);
+        try {
+          window.addEventListener('message', onReply);
+          window.postMessage({
+            __sora_uv__: true,
+            type: 'cleanup_action_request',
+            req,
+            command: 'bulk_unfollow',
+            payload: request,
+          }, PAGE_ORIGIN);
+          sendResponse({ ok: true, started: true, requestId });
+        } catch (err) {
+          finish({ ok: false, error: err?.message || 'Could not relay the cleanup action to the page.' });
+          sendResponse({ ok: false, error: err?.message || 'Could not relay the cleanup action to the page.' });
+        }
+        return false;
+      }
+      return false;
     });
   } catch {}
 

--- a/dashboard.css
+++ b/dashboard.css
@@ -664,6 +664,123 @@ body.is-purging .sidebar{
   border:2px solid rgba(var(--bg-dark-rgb),0.7);
 }
 .content::-webkit-scrollbar-track{background:rgba(var(--bg-dark-rgb),0.6)}
+.dashboard-workspaces-shell{
+  display:flex;
+  flex-direction:column;
+  gap:18px;
+  margin-bottom:18px;
+}
+.dashboard-workspaces-bar{
+  display:flex;
+  align-items:flex-end;
+  justify-content:space-between;
+  gap:18px;
+  padding:18px 20px;
+  border-radius:22px;
+  border:1px solid rgba(var(--accent-rgb),0.18);
+  background:
+    radial-gradient(130% 180% at 0% 0%, rgba(var(--accent-rgb),0.2), transparent 58%),
+    linear-gradient(140deg, rgba(var(--surface-rgb),0.9), rgba(var(--bg-alt-rgb),0.96));
+  box-shadow:var(--shadow-md);
+}
+.dashboard-workspaces-copy{
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  max-width:720px;
+}
+.dashboard-workspaces-kicker,
+.cleanup-workspace-kicker{
+  color:#b7c8dd;
+  text-transform:uppercase;
+  letter-spacing:0.14em;
+  font:700 11px/1.1 var(--font-system);
+}
+.dashboard-workspaces-title{
+  margin:0;
+  font:700 24px/1.1 var(--font-display);
+  letter-spacing:-0.03em;
+  color:var(--fg);
+}
+.dashboard-workspaces-toggle{
+  flex:0 0 auto;
+}
+.dashboard-workspace-panel{
+  display:none;
+}
+.dashboard-workspace-panel.is-active{
+  display:block;
+}
+.dashboard-workspace-panel > :first-child{
+  margin-top:0;
+}
+.cleanup-workspace-hero{
+  display:grid;
+  grid-template-columns:minmax(0, 1.2fr) minmax(280px, 0.95fr);
+  gap:18px;
+  margin-bottom:16px;
+  padding:18px 20px;
+  border-radius:22px;
+  border:1px solid rgba(var(--accent-rgb),0.16);
+  background:
+    radial-gradient(120% 160% at 100% 0%, rgba(var(--accent-rgb),0.14), transparent 58%),
+    linear-gradient(160deg, rgba(var(--panel-soft-rgb),0.9), rgba(var(--bg-alt-rgb),0.95));
+  box-shadow:var(--shadow-sm);
+}
+.cleanup-workspace-copy{
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+}
+.cleanup-workspace-title{
+  margin:0;
+  color:var(--fg);
+  font:700 28px/1.02 var(--font-display);
+  letter-spacing:-0.04em;
+  max-width:12ch;
+}
+.cleanup-workspace-note{
+  margin:0;
+  color:var(--muted);
+  font:14px/1.55 var(--font-system);
+  max-width:62ch;
+}
+.cleanup-workspace-callouts{
+  display:grid;
+  gap:10px;
+}
+.cleanup-callout{
+  display:flex;
+  gap:12px;
+  align-items:flex-start;
+  padding:12px 14px;
+  border-radius:16px;
+  border:1px solid rgba(255,255,255,0.08);
+  background:rgba(var(--panel-deep-rgb),0.46);
+}
+.cleanup-callout-step{
+  flex:0 0 auto;
+  width:28px;
+  height:28px;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  border-radius:999px;
+  background:rgba(var(--accent-rgb),0.18);
+  border:1px solid rgba(var(--accent-rgb),0.28);
+  color:var(--fg);
+  font:700 12px/1 var(--font-system);
+}
+.cleanup-callout strong{
+  display:block;
+  margin-bottom:2px;
+  color:var(--fg);
+  font:700 13px/1.2 var(--font-system);
+}
+.cleanup-callout span:last-child{
+  color:var(--muted);
+  font:12px/1.45 var(--font-system);
+}
 .chart-wrap{
   position:relative;
   border:1px solid rgba(var(--accent-rgb),0.12);
@@ -1068,6 +1185,390 @@ body.is-resizing{cursor:col-resize;user-select:none}
   font-family:var(--font-system);
   line-height:1.4;
   margin:0 0 16px;
+}
+.cleanup-planner{
+  position:relative;
+  z-index:4;
+  margin:0 0 18px;
+  padding:18px;
+  border-radius:18px;
+  border:1px solid rgba(var(--accent-rgb),0.18);
+  background:
+    radial-gradient(120% 160% at 0% 0%, rgba(var(--accent-rgb),0.16), transparent 56%),
+    linear-gradient(160deg, rgba(var(--surface-rgb),0.88), rgba(var(--bg-alt-rgb),0.96));
+  box-shadow:var(--shadow-sm);
+}
+.cleanup-planner-head{
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:16px;
+  flex-wrap:wrap;
+}
+.cleanup-planner-copy{
+  flex:1 1 360px;
+  min-width:0;
+}
+.cleanup-planner-copy .section-title{
+  margin-bottom:6px;
+}
+.cleanup-planner-copy .section-note{
+  margin-bottom:0;
+}
+.cleanup-planner-controls{
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+  align-items:flex-end;
+}
+.cleanup-input{
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  min-width:118px;
+  color:var(--muted);
+  font-size:12px;
+  font-family:var(--font-system);
+}
+.cleanup-input input{
+  width:100%;
+  min-height:40px;
+  padding:10px 12px;
+  border-radius:12px;
+  border:1px solid rgba(255,255,255,0.12);
+  background:rgba(var(--panel-mid-rgb),0.72);
+  color:var(--fg);
+  font-size:14px;
+  font-family:var(--font-system);
+  font-variant-numeric:tabular-nums;
+}
+.cleanup-input input:focus{
+  outline:none;
+  border-color:rgba(var(--accent-rgb),0.45);
+  box-shadow:0 0 0 1px rgba(var(--accent-rgb),0.2);
+}
+.cleanup-metric-grid{
+  margin-top:16px;
+  margin-bottom:16px;
+}
+.cleanup-planner-columns{
+  display:grid;
+  grid-template-columns:repeat(2, minmax(0, 1fr));
+  gap:16px;
+}
+.cleanup-panel{
+  border-radius:18px;
+  border:1px solid rgba(255,255,255,0.08);
+  background:rgba(var(--panel-mid-rgb),0.58);
+  padding:16px;
+  min-width:0;
+}
+.cleanup-panel-head-row{
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:12px;
+  flex-wrap:wrap;
+}
+.cleanup-panel-title{
+  margin:0;
+  color:var(--fg);
+  font-size:13px;
+  font-weight:700;
+  letter-spacing:0.02em;
+  font-family:var(--font-system);
+}
+.cleanup-panel-meta{
+  margin-top:5px;
+  color:var(--muted);
+  font-size:12px;
+  font-family:var(--font-system);
+}
+.cleanup-panel-actions{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  align-items:center;
+}
+.cleanup-quick-filters{
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:14px;
+  margin-top:14px;
+  padding:14px 0 2px;
+  border-top:1px solid rgba(255,255,255,0.07);
+}
+.cleanup-quick-filters-copy{
+  flex:0 1 240px;
+  min-width:180px;
+}
+.cleanup-quick-filters-label{
+  color:var(--fg);
+  font:700 12px/1.2 var(--font-system);
+  letter-spacing:0.06em;
+  text-transform:uppercase;
+}
+.cleanup-quick-filters-note{
+  margin-top:6px;
+  color:var(--muted);
+  font:12px/1.45 var(--font-system);
+}
+.cleanup-quick-filter-buttons{
+  display:flex;
+  flex:1 1 auto;
+  flex-wrap:wrap;
+  gap:8px;
+}
+.cleanup-filter-row{
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+  margin-top:12px;
+}
+.cleanup-input--search{
+  flex:1 1 200px;
+}
+.cleanup-input--select{
+  min-width:132px;
+}
+.cleanup-input--rows{
+  min-width:88px;
+}
+.cleanup-input select{
+  width:100%;
+  min-height:40px;
+  padding:10px 12px;
+  border-radius:12px;
+  border:1px solid rgba(255,255,255,0.12);
+  background:rgba(var(--panel-mid-rgb),0.72);
+  color:var(--fg);
+  font-size:14px;
+  font-family:var(--font-system);
+}
+.cleanup-input select:focus{
+  outline:none;
+  border-color:rgba(var(--accent-rgb),0.45);
+  box-shadow:0 0 0 1px rgba(var(--accent-rgb),0.2);
+}
+.cleanup-panel-note{
+  margin-top:12px;
+  color:var(--muted);
+  font-size:12px;
+  line-height:1.45;
+  font-family:var(--font-system);
+}
+.cleanup-panel-note--success{
+  color:#9ef2bb;
+}
+.cleanup-panel-note--warn{
+  color:#ffe1b0;
+}
+.cleanup-panel-note--danger{
+  color:#ffc8d2;
+}
+.cleanup-list{
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+  margin-top:12px;
+}
+.cleanup-empty{
+  padding:12px 0;
+  color:var(--muted);
+  font-size:13px;
+  line-height:1.5;
+  font-family:var(--font-system);
+}
+.cleanup-item{
+  padding:12px;
+  border-radius:14px;
+  border:1px solid rgba(255,255,255,0.08);
+  background:rgba(var(--panel-deep-rgb),0.58);
+}
+.cleanup-item--selectable{
+  position:relative;
+}
+.cleanup-item-head{
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:12px;
+}
+.cleanup-item-head-main{
+  display:flex;
+  align-items:flex-start;
+  gap:10px;
+  min-width:0;
+  flex:1 1 auto;
+}
+.cleanup-item-select{
+  display:inline-flex;
+  align-items:center;
+  padding-top:2px;
+}
+.cleanup-item-select input{
+  width:16px;
+  height:16px;
+  margin:0;
+  accent-color:var(--accent);
+}
+.cleanup-item-identity{
+  min-width:0;
+}
+.cleanup-item-link{
+  color:var(--fg);
+  font-size:14px;
+  font-weight:700;
+  text-decoration:none;
+  font-family:var(--font-system);
+}
+.cleanup-item-link:hover{
+  color:var(--accent);
+  text-decoration:underline;
+}
+.cleanup-item-name{
+  margin-top:2px;
+  color:var(--muted);
+  font-size:12px;
+  font-family:var(--font-system);
+}
+.cleanup-item-score{
+  flex:0 0 auto;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  padding:5px 9px;
+  border-radius:999px;
+  background:rgba(var(--accent-rgb),0.14);
+  border:1px solid rgba(var(--accent-rgb),0.24);
+  color:var(--fg);
+  font-size:12px;
+  font-weight:700;
+  font-variant-numeric:tabular-nums;
+  font-family:var(--font-system);
+}
+.cleanup-item-meta{
+  margin-top:8px;
+  color:var(--muted);
+  font-size:12px;
+  line-height:1.45;
+  font-family:var(--font-system);
+}
+.cleanup-item-badges{
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px;
+  margin-top:10px;
+}
+.cleanup-badge{
+  display:inline-flex;
+  align-items:center;
+  padding:4px 8px;
+  border-radius:999px;
+  font-size:11px;
+  font-weight:700;
+  letter-spacing:0.01em;
+  font-family:var(--font-system);
+}
+.cleanup-badge--danger{
+  background:rgba(255,96,120,0.18);
+  border:1px solid rgba(255,96,120,0.28);
+  color:#ffc8d2;
+}
+.cleanup-badge--warn{
+  background:rgba(255,198,112,0.16);
+  border:1px solid rgba(255,198,112,0.26);
+  color:#ffe1b0;
+}
+.cleanup-badge--soft{
+  background:rgba(120,212,255,0.14);
+  border:1px solid rgba(120,212,255,0.24);
+  color:#d2efff;
+}
+.cleanup-item-recommendation{
+  margin-top:10px;
+  color:var(--fg);
+  font-size:12px;
+  font-weight:700;
+  font-family:var(--font-system);
+}
+.cleanup-item-actions{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:10px;
+  margin-top:12px;
+  flex-wrap:wrap;
+}
+.cleanup-item-action-note{
+  color:var(--muted);
+  font-size:11px;
+  font-family:var(--font-system);
+}
+.cleanup-pagination{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:10px;
+  margin-top:12px;
+  flex-wrap:wrap;
+}
+.cleanup-pagination-label{
+  flex:1 1 auto;
+  text-align:center;
+  color:var(--muted);
+  font-size:12px;
+  font-family:var(--font-system);
+}
+.cleanup-btn{
+  appearance:none;
+  border:1px solid transparent;
+  border-radius:999px;
+  min-height:34px;
+  padding:7px 12px;
+  font-size:12px;
+  font-weight:700;
+  font-family:var(--font-system);
+  cursor:pointer;
+  transition:background .16s ease, border-color .16s ease, color .16s ease, opacity .16s ease, transform .16s ease;
+}
+.cleanup-btn:hover:not(:disabled){
+  transform:translateY(-1px);
+}
+.cleanup-btn:disabled{
+  opacity:.48;
+  cursor:not-allowed;
+}
+.cleanup-btn--ghost{
+  background:rgba(var(--panel-deep-rgb),0.78);
+  border:1px solid rgba(255,255,255,0.12);
+  color:var(--fg);
+}
+.cleanup-btn--ghost:hover:not(:disabled){
+  border-color:rgba(var(--accent-rgb),0.28);
+}
+.cleanup-btn--danger{
+  background:rgba(255,96,120,0.2);
+  border:1px solid rgba(255,96,120,0.28);
+  color:#ffd3db;
+}
+.cleanup-btn--danger:hover:not(:disabled){
+  background:rgba(255,96,120,0.28);
+}
+.cleanup-btn--quick{
+  background:rgba(var(--panel-deep-rgb),0.74);
+  border:1px solid rgba(255,255,255,0.1);
+  color:var(--fg);
+}
+.cleanup-btn--quick:hover:not(:disabled){
+  border-color:rgba(var(--accent-rgb),0.32);
+}
+.cleanup-btn--quick.active{
+  background:rgba(var(--accent-rgb),0.18);
+  border-color:rgba(var(--accent-rgb),0.4);
+  color:var(--fg);
+  box-shadow:0 0 0 1px rgba(var(--accent-rgb),0.18) inset;
 }
 .views-toggle{
   margin-top:24px;
@@ -1802,11 +2303,36 @@ body.is-resizing{cursor:col-resize;user-select:none}
   }
 }
 @media (max-width: 860px){
+  .dashboard-workspaces-bar{align-items:flex-start;flex-direction:column;}
+  .cleanup-workspace-hero{grid-template-columns:1fr;}
   .best-time-body{grid-template-columns:1fr;}
   .best-time-header{flex-direction:column;align-items:flex-start;}
   .best-time-subtitle{white-space:normal;}
   .best-time-toggle{margin-left:0;}
   .best-time-context{min-width:0;}
+  .cleanup-planner-columns{grid-template-columns:1fr;}
+}
+@media (max-width: 720px){
+  .dashboard-workspaces-bar,
+  .cleanup-workspace-hero{padding:16px;}
+  .dashboard-workspaces-title{font-size:20px;}
+  .cleanup-workspace-title{font-size:24px;max-width:none;}
+  .dashboard-workspaces-toggle{width:100%;}
+  .cleanup-planner{padding:14px;}
+  .cleanup-planner-controls{width:100%;}
+  .cleanup-input{flex:1 1 120px;}
+  .cleanup-item-head{flex-direction:column;align-items:flex-start;}
+  .cleanup-item-head-main{width:100%;}
+  .cleanup-item-score{align-self:flex-start;}
+  .cleanup-panel-actions{width:100%;}
+  .cleanup-quick-filters{flex-direction:column;}
+  .cleanup-quick-filters-copy{max-width:none;}
+  .cleanup-filter-row{flex-direction:column;}
+  .cleanup-input--search,
+  .cleanup-input--select,
+  .cleanup-input--rows{width:100%;}
+  .cleanup-pagination{justify-content:flex-start;}
+  .cleanup-pagination-label{text-align:left;}
 }
 .compare-pill-name{
   user-select:none;

--- a/dashboard.html
+++ b/dashboard.html
@@ -100,6 +100,51 @@
       </div>
     </aside>
     <section class="content">
+      <section class="dashboard-workspaces-shell" aria-label="Dashboard workspace switcher">
+        <div class="dashboard-workspaces-bar">
+          <div class="dashboard-workspaces-copy">
+            <div class="dashboard-workspaces-kicker">Workspace</div>
+            <h2 class="dashboard-workspaces-title">Choose the view that matches what you are doing right now.</h2>
+          </div>
+          <div class="dashboard-workspaces-toggle toggle-group toggle-group--lg" role="tablist" aria-label="Dashboard workspaces">
+            <button id="dashboardWorkspaceOverview" class="toggle-pill toggle-pill--lg" type="button" data-workspace-target="overview" aria-selected="true">Overview</button>
+            <button id="dashboardWorkspaceCleanup" class="toggle-pill toggle-pill--lg" type="button" data-workspace-target="cleanup" aria-selected="false">Followers &amp; Following</button>
+          </div>
+        </div>
+        <section id="dashboardOverviewWorkspace" class="dashboard-workspace-panel" data-workspace-panel="overview" aria-label="Overview workspace"></section>
+        <section id="dashboardCleanupWorkspace" class="dashboard-workspace-panel" data-workspace-panel="cleanup" aria-label="Followers and following workspace">
+          <div class="cleanup-workspace-hero">
+            <div class="cleanup-workspace-copy">
+              <div class="cleanup-workspace-kicker">Relationship Graph</div>
+              <h3 class="cleanup-workspace-title">Audit your network without getting buried in the rest of the dashboard.</h3>
+              <p class="cleanup-workspace-note">Harvest followers and following from Sora, isolate low-signal accounts quickly, then batch-review who still deserves your attention.</p>
+            </div>
+            <div class="cleanup-workspace-callouts" aria-label="Cleanup workflow">
+              <div class="cleanup-callout">
+                <span class="cleanup-callout-step">1</span>
+                <div>
+                  <strong>Harvest</strong>
+                  <span>Open the Sora relationship modal and capture both lists.</span>
+                </div>
+              </div>
+              <div class="cleanup-callout">
+                <span class="cleanup-callout-step">2</span>
+                <div>
+                  <strong>Filter</strong>
+                  <span>Use focus filters to surface non-mutual, stale, or zero-signal accounts.</span>
+                </div>
+              </div>
+              <div class="cleanup-callout">
+                <span class="cleanup-callout-step">3</span>
+                <div>
+                  <strong>Act</strong>
+                  <span>Select a page, the filtered set, or zero-signal accounts and bulk unfollow safely.</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </section>
       <div id="bestTimeToPostSection">
         <div class="best-time-header">
           <div>
@@ -226,6 +271,200 @@
           <span class="label">Followers</span>
         </div>
       </div>
+      <section id="cleanupPlannerSection" class="cleanup-planner">
+        <div class="cleanup-planner-head">
+          <div class="cleanup-planner-copy">
+            <h3 class="section-title section-title-first">Clean Following Planner</h3>
+            <p id="cleanupPlannerNote" class="section-note">Open a profile on Sora, then open the Followers or Following modal to collect relationship data for cleanup planning.</p>
+          </div>
+          <div class="cleanup-planner-controls" aria-label="Cleanup planner thresholds">
+            <label class="cleanup-input">
+              <span>Max followers</span>
+              <input id="cleanupMaxFollowers" type="number" min="0" step="10" value="200" />
+            </label>
+            <label class="cleanup-input">
+              <span>Min posts</span>
+              <input id="cleanupMinPosts" type="number" min="0" step="1" value="12" />
+            </label>
+            <label class="cleanup-input">
+              <span>Min likes received</span>
+              <input id="cleanupMinLikesReceived" type="number" min="0" step="5" value="120" />
+            </label>
+            <label class="cleanup-input">
+              <span>Inactive days</span>
+              <input id="cleanupStaleDays" type="number" min="1" step="1" value="45" />
+            </label>
+          </div>
+        </div>
+        <div class="metric-grid cleanup-metric-grid">
+          <div class="metric-card" title="Captured followers from the relationship graph">
+            <span id="cleanupFollowersCaptured" class="value">0</span>
+            <span class="label">Followers Captured</span>
+          </div>
+          <div class="metric-card" title="Captured following accounts from the relationship graph">
+            <span id="cleanupFollowingCaptured" class="value">0</span>
+            <span class="label">Following Captured</span>
+          </div>
+          <div class="metric-card" title="Accounts captured in both followers and following lists">
+            <span id="cleanupMutualCaptured" class="value">0</span>
+            <span class="label">Mutuals</span>
+          </div>
+          <div class="metric-card" title="High-confidence unfollow suggestions">
+            <span id="cleanupLikelyCount" class="value">0</span>
+            <span class="label">Unfollow Likely</span>
+          </div>
+          <div class="metric-card" title="Low-signal followers that may be worth a manual review">
+            <span id="cleanupFollowerReviewCount" class="value">0</span>
+            <span class="label">Follower Review</span>
+          </div>
+        </div>
+        <div class="cleanup-planner-columns">
+          <div class="cleanup-panel">
+            <div class="cleanup-panel-head-row">
+              <div>
+                <div class="cleanup-panel-title">Following cleanup</div>
+                <div id="cleanupFollowingPanelMeta" class="cleanup-panel-meta">0 matches</div>
+              </div>
+              <div class="cleanup-panel-actions">
+                <button id="cleanupSelectFollowingPage" type="button" class="cleanup-btn cleanup-btn--ghost">Select page</button>
+                <button id="cleanupSelectFollowingFiltered" type="button" class="cleanup-btn cleanup-btn--ghost">Select visible</button>
+                <button id="cleanupSelectFollowingZeroSignal" type="button" class="cleanup-btn cleanup-btn--ghost">Select zero-signal</button>
+                <button id="cleanupClearFollowingSelection" type="button" class="cleanup-btn cleanup-btn--ghost">Clear</button>
+                <button id="cleanupUnfollowSelected" type="button" class="cleanup-btn cleanup-btn--danger" disabled>Unfollow selected</button>
+              </div>
+            </div>
+            <div class="cleanup-quick-filters" aria-label="Suggested unfollow filters">
+              <div class="cleanup-quick-filters-copy">
+                <div class="cleanup-quick-filters-label">Suggested views</div>
+                <div class="cleanup-quick-filters-note">Start here when you want obvious unfollows instead of browsing the full list.</div>
+              </div>
+              <div class="cleanup-quick-filter-buttons" role="group" aria-label="Suggested following filters">
+                <button id="cleanupPresetFollowingSmart" type="button" class="cleanup-btn cleanup-btn--quick" data-cleanup-preset="smart_unfollow">Should unfollow</button>
+                <button id="cleanupPresetFollowingZeroSignal" type="button" class="cleanup-btn cleanup-btn--quick" data-cleanup-preset="zero_signal">Zero-signal</button>
+                <button id="cleanupPresetFollowingNonMutual" type="button" class="cleanup-btn cleanup-btn--quick" data-cleanup-preset="non_mutual">Not following back</button>
+                <button id="cleanupPresetFollowingInactive" type="button" class="cleanup-btn cleanup-btn--quick" data-cleanup-preset="inactive">Inactive</button>
+                <button id="cleanupPresetFollowingLowLikes" type="button" class="cleanup-btn cleanup-btn--quick" data-cleanup-preset="low_likes">Low likes</button>
+                <button id="cleanupPresetFollowingAll" type="button" class="cleanup-btn cleanup-btn--quick" data-cleanup-preset="all">Show all</button>
+              </div>
+            </div>
+            <div class="cleanup-filter-row" aria-label="Following filters">
+              <label class="cleanup-input cleanup-input--search">
+                <span>Search</span>
+                <input id="cleanupFollowingSearch" type="search" placeholder="Handle or display name" />
+              </label>
+              <label class="cleanup-input cleanup-input--select">
+                <span>Status</span>
+                <select id="cleanupFollowingStatus">
+                  <option value="all">All</option>
+                  <option value="actionable">Unfollow likely</option>
+                  <option value="review">Review soon</option>
+                  <option value="low_priority">Low priority</option>
+                </select>
+              </label>
+              <label class="cleanup-input cleanup-input--select">
+                <span>Focus</span>
+                <select id="cleanupFollowingReason">
+                  <option value="all">All reasons</option>
+                  <option value="smart_unfollow">Should unfollow</option>
+                  <option value="non_mutual">Not following back</option>
+                  <option value="inactive">Inactive</option>
+                  <option value="low_followers">Low followers</option>
+                  <option value="low_posts">Low posts</option>
+                  <option value="low_likes">Low likes received</option>
+                  <option value="zero_signal">0 followers • 0 posts • 0 likes • inactive</option>
+                  <option value="verified">Verified</option>
+                </select>
+              </label>
+              <label class="cleanup-input cleanup-input--select">
+                <span>Sort</span>
+                <select id="cleanupFollowingSort">
+                  <option value="score_desc">Highest score</option>
+                  <option value="stale_desc">Most inactive</option>
+                  <option value="followers_asc">Fewest followers</option>
+                  <option value="posts_asc">Fewest posts</option>
+                  <option value="likes_asc">Fewest likes received</option>
+                  <option value="handle_asc">A-Z</option>
+                </select>
+              </label>
+              <label class="cleanup-input cleanup-input--select cleanup-input--rows">
+                <span>Rows</span>
+                <select id="cleanupFollowingPageSize">
+                  <option value="10">10</option>
+                  <option value="25" selected>25</option>
+                  <option value="50">50</option>
+                </select>
+              </label>
+            </div>
+            <div id="cleanupFollowingActionNote" class="cleanup-panel-note">Select zero-signal grabs non-mutual follows with 0 followers, 0 posts, 0 likes, and stale activity. Bulk unfollow uses your live Sora tab and the native Following buttons.</div>
+            <div id="cleanupFollowingList" class="cleanup-list" aria-live="polite"></div>
+            <div class="cleanup-pagination" aria-label="Following pagination">
+              <button id="cleanupFollowingPrev" type="button" class="cleanup-btn cleanup-btn--ghost">Prev</button>
+              <div id="cleanupFollowingPagination" class="cleanup-pagination-label">Page 1 of 1</div>
+              <button id="cleanupFollowingNext" type="button" class="cleanup-btn cleanup-btn--ghost">Next</button>
+            </div>
+          </div>
+          <div class="cleanup-panel">
+            <div class="cleanup-panel-head-row">
+              <div>
+                <div class="cleanup-panel-title">Low-signal followers</div>
+                <div id="cleanupFollowersPanelMeta" class="cleanup-panel-meta">0 matches</div>
+              </div>
+            </div>
+            <div class="cleanup-filter-row" aria-label="Follower filters">
+              <label class="cleanup-input cleanup-input--search">
+                <span>Search</span>
+                <input id="cleanupFollowersSearch" type="search" placeholder="Handle or display name" />
+              </label>
+              <label class="cleanup-input cleanup-input--select">
+                <span>Status</span>
+                <select id="cleanupFollowersStatus">
+                  <option value="all">All</option>
+                  <option value="actionable">Low-signal follower</option>
+                  <option value="review">Manual review</option>
+                  <option value="low_priority">Low priority</option>
+                </select>
+              </label>
+              <label class="cleanup-input cleanup-input--select">
+                <span>Focus</span>
+                <select id="cleanupFollowersReason">
+                  <option value="all">All reasons</option>
+                  <option value="non_mutual">You do not follow back</option>
+                  <option value="inactive">Inactive</option>
+                  <option value="low_followers">Low followers</option>
+                  <option value="low_posts">Low posts</option>
+                  <option value="low_likes">Low engagement</option>
+                  <option value="verified">Verified</option>
+                </select>
+              </label>
+              <label class="cleanup-input cleanup-input--select">
+                <span>Sort</span>
+                <select id="cleanupFollowersSort">
+                  <option value="score_desc">Highest score</option>
+                  <option value="stale_desc">Most inactive</option>
+                  <option value="followers_asc">Fewest followers</option>
+                  <option value="posts_asc">Fewest posts</option>
+                  <option value="handle_asc">A-Z</option>
+                </select>
+              </label>
+              <label class="cleanup-input cleanup-input--select cleanup-input--rows">
+                <span>Rows</span>
+                <select id="cleanupFollowersPageSize">
+                  <option value="10">10</option>
+                  <option value="25" selected>25</option>
+                  <option value="50">50</option>
+                </select>
+              </label>
+            </div>
+            <div id="cleanupFollowersActionNote" class="cleanup-panel-note">Follower rows are review-only until Sora exposes a safe remove-follower path.</div>
+            <div id="cleanupFollowersList" class="cleanup-list" aria-live="polite"></div>
+            <div class="cleanup-pagination" aria-label="Follower pagination">
+              <button id="cleanupFollowersPrev" type="button" class="cleanup-btn cleanup-btn--ghost">Prev</button>
+              <div id="cleanupFollowersPagination" class="cleanup-pagination-label">Page 1 of 1</div>
+              <button id="cleanupFollowersNext" type="button" class="cleanup-btn cleanup-btn--ghost">Next</button>
+            </div>
+          </div>
+        </div>
+      </section>
       <div class="views-toggle">
         <div class="toggle-group toggle-group--lg" role="group" aria-label="View type">
           <button id="totalViewsPill" class="views-pill toggle-pill toggle-pill--lg active" data-type="total" aria-pressed="true">Total Views</button>

--- a/dashboard.js
+++ b/dashboard.js
@@ -387,6 +387,38 @@
   let lastSessionCacheAt = 0;
   let currentUserKey = null;
   let lastSelectedUserKey = null;
+  const CLEANUP_PANEL_KINDS = ['following', 'followers'];
+  const CLEANUP_PANEL_FILTER_DEFAULTS = Object.freeze({
+    search: '',
+    status: 'all',
+    reason: 'all',
+    sort: 'score_desc',
+    page: 1,
+    pageSize: 25,
+  });
+  const CLEANUP_BULK_UNFOLLOW_LIMIT = 100;
+  const CLEANUP_ZERO_SIGNAL_HINT = 'Select zero-signal grabs non-mutual follows with 0 followers, 0 posts, 0 likes, and stale activity. Bulk unfollow uses your live Sora tab and the native Following buttons.';
+  const CLEANUP_FOLLOWING_PRESET_DEFS = Object.freeze([
+    { id: 'smart_unfollow', label: 'Should unfollow' },
+    { id: 'zero_signal', label: 'Zero-signal' },
+    { id: 'non_mutual', label: 'Not following back' },
+    { id: 'inactive', label: 'Inactive' },
+    { id: 'low_likes', label: 'Low likes' },
+    { id: 'all', label: 'Show all' },
+  ]);
+  const DASHBOARD_WORKSPACE_STORAGE_KEY = 'SCT_DASHBOARD_WORKSPACE_V1';
+  let cleanupPlannerContextKey = null;
+  let cleanupPlannerContextUser = null;
+  let cleanupPlannerContextPlan = null;
+  let cleanupBulkActionBusy = false;
+  let cleanupBulkActionTone = 'muted';
+  let cleanupBulkActionMessage = '';
+  const cleanupSelectedFollowingKeys = new Set();
+  let activeDashboardWorkspace = 'overview';
+  const cleanupPanelState = {
+    following: { ...CLEANUP_PANEL_FILTER_DEFAULTS, preset: 'all' },
+    followers: { ...CLEANUP_PANEL_FILTER_DEFAULTS },
+  };
   let nextAutoRefreshAt = 0;
   let autoRefreshCountdownTimer = null;
   let triggerMetricsAutoRefreshNow = null;
@@ -1941,6 +1973,77 @@
     }
     return merged;
   }
+  function cloneRelationshipGraphNode(node) {
+    if (!node || typeof node !== 'object') return null;
+    return { ...node };
+  }
+  function cloneRelationshipGraphEdge(edge) {
+    if (!edge || typeof edge !== 'object') return null;
+    return { ...edge };
+  }
+  function relationshipGraphHasData(graph) {
+    if (!graph || typeof graph !== 'object') return false;
+    const nodes = graph.nodes && typeof graph.nodes === 'object' ? Object.keys(graph.nodes).length : 0;
+    const followers = graph.edges?.followers && typeof graph.edges.followers === 'object' ? Object.keys(graph.edges.followers).length : 0;
+    const following = graph.edges?.following && typeof graph.edges.following === 'object' ? Object.keys(graph.edges.following).length : 0;
+    const fullSyncFollowers = toTs(graph.fullSyncAt?.followers) || 0;
+    const fullSyncFollowing = toTs(graph.fullSyncAt?.following) || 0;
+    return nodes > 0 || followers > 0 || following > 0 || fullSyncFollowers > 0 || fullSyncFollowing > 0;
+  }
+  function mergeRelationshipGraphs(graphs) {
+    const merged = {
+      nodes: {},
+      edges: { followers: {}, following: {} },
+      fullSyncAt: {},
+      updatedAt: 0
+    };
+    let hasData = false;
+    const latestFullSyncAt = { followers: 0, following: 0 };
+    for (const graph of graphs || []) {
+      if (!relationshipGraphHasData(graph)) continue;
+      for (const kind of ['followers', 'following']) {
+        const nextFullSyncAt = toTs(graph.fullSyncAt?.[kind]) || 0;
+        if (nextFullSyncAt > latestFullSyncAt[kind]) latestFullSyncAt[kind] = nextFullSyncAt;
+      }
+    }
+    for (const kind of ['followers', 'following']) {
+      if (latestFullSyncAt[kind] > 0) merged.fullSyncAt[kind] = latestFullSyncAt[kind];
+    }
+    for (const graph of graphs || []) {
+      if (!relationshipGraphHasData(graph)) continue;
+      hasData = true;
+      const nodes = graph.nodes && typeof graph.nodes === 'object' ? graph.nodes : {};
+      for (const [key, node] of Object.entries(nodes)) {
+        if (!key || !node || typeof node !== 'object') continue;
+        const prev = merged.nodes[key];
+        const prevSeen = toTs(prev?.lastSeenAt) || 0;
+        const nextSeen = toTs(node?.lastSeenAt) || 0;
+        const base = prev && prevSeen > nextSeen ? { ...node, ...prev } : { ...prev, ...node };
+        if (!base.user_key) base.user_key = key;
+        merged.nodes[key] = base;
+      }
+      for (const kind of ['followers', 'following']) {
+        const bucket = graph.edges?.[kind] && typeof graph.edges[kind] === 'object' ? graph.edges[kind] : {};
+        const graphFullSyncAt = toTs(graph.fullSyncAt?.[kind]) || 0;
+        for (const [key, edge] of Object.entries(bucket)) {
+          if (!key || !edge || typeof edge !== 'object') continue;
+          const edgeSeen = toTs(edge?.seenAt) || 0;
+          if (latestFullSyncAt[kind] > 0 && graphFullSyncAt < latestFullSyncAt[kind] && edgeSeen < latestFullSyncAt[kind]) {
+            continue;
+          }
+          const prev = merged.edges[kind][key];
+          const prevSeen = toTs(prev?.seenAt) || 0;
+          const nextSeen = edgeSeen;
+          const base = prev && prevSeen > nextSeen ? { ...edge, ...prev } : { ...prev, ...edge };
+          if (!base.user_key) base.user_key = key;
+          merged.edges[kind][key] = base;
+        }
+      }
+      const updatedAt = toTs(graph.updatedAt) || 0;
+      if (updatedAt > (toTs(merged.updatedAt) || 0)) merged.updatedAt = graph.updatedAt;
+    }
+    return hasData ? merged : null;
+  }
   function buildMergedIdentityUser(metrics, userKey, user = null){
     const resolvedUser = user || resolveUserForKey(metrics, userKey);
     if (!resolvedUser || isVirtualUserKey(userKey)) {
@@ -1963,6 +2066,7 @@
     const aliasKeys = Array.from(new Set([canonicalKey, userKey, ...findAliasKeysForUser(metrics, canonicalKey, canonicalUser)]));
     const allFollowerArrays = [];
     const allCameoArrays = [];
+    const relationshipGraphs = [];
     const postGroups = new Map();
     let sourcePostCount = 0;
     let sourceSnapshotCount = 0;
@@ -1975,6 +2079,9 @@
       if (Array.isArray(bucket.cameos) && bucket.cameos.length) {
         allCameoArrays.push(bucket.cameos);
       }
+      if (relationshipGraphHasData(bucket.relationshipGraph)) {
+        relationshipGraphs.push(bucket.relationshipGraph);
+      }
       for (const [pid, post] of Object.entries(bucket.posts || {})) {
         sourcePostCount++;
         sourceSnapshotCount += Array.isArray(post?.snapshots) ? post.snapshots.length : 0;
@@ -1984,6 +2091,7 @@
     }
     const mergedFollowers = mergeTimeSeriesArrays(allFollowerArrays);
     const mergedCameos = mergeTimeSeriesArrays(allCameoArrays);
+    const mergedRelationshipGraph = mergeRelationshipGraphs(relationshipGraphs);
     const mergedPosts = {};
     let mergedSnapshotCount = 0;
     let mergedPostsWithMultipleBuckets = 0;
@@ -2021,6 +2129,7 @@
       followers: mergedFollowers,
       cameos: mergedCameos
     };
+    if (mergedRelationshipGraph) mergedUser.relationshipGraph = mergedRelationshipGraph;
     return {
       user: mergedUser,
       meta: {
@@ -2033,6 +2142,143 @@
         mergedPostsWithMultipleBuckets,
         mergedDuplicateSnapshotTimestamps
       }
+    };
+  }
+  function buildCleanupPlannerModel(user, opts = {}, nowMs = Date.now()){
+    const graph = user?.relationshipGraph;
+    const empty = {
+      summary: {
+        followersCaptured: 0,
+        followingCaptured: 0,
+        mutualCount: 0,
+        nonMutualFollowingCount: 0,
+        zeroSignalFollowingCount: 0,
+        unfollowLikelyCount: 0,
+        lowSignalFollowersCount: 0
+      },
+      following: [],
+      followers: []
+    };
+    if (!relationshipGraphHasData(graph)) return empty;
+    const maxFollowers = Math.max(0, Number(opts.maxFollowers) || 200);
+    const minPosts = Math.max(0, Number(opts.minPosts) || 12);
+    const staleDays = Math.max(0, Number(opts.staleDays) || 45);
+    const minLikesReceived = Math.max(0, Number(opts.minLikesReceived) || Math.max(50, minPosts * 10));
+    const followingEdges = graph.edges?.following && typeof graph.edges.following === 'object' ? graph.edges.following : {};
+    const followerEdges = graph.edges?.followers && typeof graph.edges.followers === 'object' ? graph.edges.followers : {};
+    const nodes = graph.nodes && typeof graph.nodes === 'object' ? graph.nodes : {};
+    const followingKeys = Object.keys(followingEdges);
+    const followerKeys = Object.keys(followerEdges);
+    const mutualSet = new Set(followingKeys.filter((key)=> Object.prototype.hasOwnProperty.call(followerEdges, key)));
+    const scoreCandidate = (targetKey, primaryKind) => {
+      const node = nodes[targetKey] || {};
+      const followingEdge = followingEdges[targetKey] || null;
+      const followerEdge = followerEdges[targetKey] || null;
+      const mutual = !!(followingEdge && followerEdge);
+      const followerCount = Number.isFinite(Number(node?.follower_count)) ? Number(node.follower_count) : null;
+      const postCount = Number.isFinite(Number(node?.post_count)) ? Number(node.post_count) : null;
+      const likesReceivedCount = Number.isFinite(Number(node?.likes_received_count)) ? Number(node.likes_received_count) : null;
+      const replyCount = Number.isFinite(Number(node?.reply_count)) ? Number(node.reply_count) : 0;
+      const remixCount = Number.isFinite(Number(node?.remix_count)) ? Number(node.remix_count) : 0;
+      const cameoCount = Number.isFinite(Number(node?.cameo_count)) ? Number(node.cameo_count) : 0;
+      const updatedAtMs = toTs(node?.updated_at);
+      const inactiveDays = updatedAtMs > 0 ? Math.max(0, Math.floor((nowMs - updatedAtMs) / (24 * 60 * 60 * 1000))) : null;
+      const engagementSignal = Math.max(0, (likesReceivedCount || 0) + replyCount * 3 + remixCount * 5 + cameoCount * 2);
+      const followsYou = typeof followerEdge?.follows_you === 'boolean'
+        ? followerEdge.follows_you
+        : (typeof followingEdge?.follows_you === 'boolean' ? followingEdge.follows_you : mutual);
+      const isFollowing = typeof followingEdge?.is_following === 'boolean'
+        ? followingEdge.is_following
+        : (typeof followerEdge?.is_following === 'boolean' ? followerEdge.is_following : !!followingEdge);
+      const nonMutual = primaryKind === 'following' ? !followsYou : !isFollowing;
+      const lowFollowers = maxFollowers > 0 && followerCount != null && followerCount < maxFollowers;
+      const lowPosts = minPosts > 0 && postCount != null && postCount < minPosts;
+      const lowLikes = likesReceivedCount != null && likesReceivedCount < minLikesReceived;
+      const inactive = staleDays > 0 && inactiveDays != null && inactiveDays >= staleDays;
+      const zeroSignal = primaryKind === 'following'
+        && nonMutual
+        && inactive
+        && followerCount === 0
+        && postCount === 0
+        && likesReceivedCount === 0;
+      let score = 0;
+      const reasons = [];
+      if (nonMutual) {
+        score += 34;
+        reasons.push({ label: primaryKind === 'following' ? 'not following you back' : 'you do not follow back', tone: 'danger' });
+      }
+      if (lowFollowers) {
+        score += 18;
+        reasons.push({ label: `${followerCount} followers`, tone: 'warn' });
+      }
+      if (lowPosts) {
+        score += 16;
+        reasons.push({ label: `${postCount} posts`, tone: 'warn' });
+      }
+      if (lowLikes) {
+        score += 12;
+        reasons.push({ label: `${likesReceivedCount} likes received`, tone: 'soft' });
+      }
+      if (inactive) {
+        score += 18;
+        reasons.push({ label: `inactive ${inactiveDays}d`, tone: 'danger' });
+      }
+      if (mutual) score -= 12;
+      if (node?.verified) score -= 22;
+      if (maxFollowers > 0 && followerCount != null && followerCount >= maxFollowers * 4) score -= 12;
+      if (minPosts > 0 && postCount != null && postCount >= minPosts * 4) score -= 8;
+      if (engagementSignal >= minLikesReceived * 6) score -= 10;
+      score = Math.max(0, Math.min(99, score));
+      return {
+        userKey: targetKey,
+        userHandle: node?.user_handle || followingEdge?.user_handle || followerEdge?.user_handle || null,
+        userId: node?.user_id || followingEdge?.user_id || followerEdge?.user_id || null,
+        displayName: node?.display_name || null,
+        permalink: node?.permalink || null,
+        followerCount,
+        postCount,
+        likesReceivedCount,
+        engagementSignal,
+        updatedAtMs,
+        inactiveDays,
+        verified: !!node?.verified,
+        mutual,
+        followsYou,
+        isFollowing,
+        nonMutual,
+        lowFollowers,
+        lowPosts,
+        lowLikes,
+        inactive,
+        zeroSignal,
+        selectable: primaryKind === 'following' && !!isFollowing && !!(node?.user_handle || followingEdge?.user_handle || followerEdge?.user_handle),
+        score,
+        reasons,
+        recommendation: primaryKind === 'following'
+          ? (score >= 60 ? 'Unfollow likely' : score >= 40 ? 'Review soon' : 'Low priority')
+          : (score >= 55 ? 'Low-signal follower' : score >= 35 ? 'Manual review' : 'Low priority')
+      };
+    };
+    const following = followingKeys
+      .map((key)=>scoreCandidate(key, 'following'))
+      .filter((item)=>item.score >= 25 || item.reasons.length >= 2)
+      .sort((a, b)=> (b.score - a.score) || ((a.followerCount ?? Infinity) - (b.followerCount ?? Infinity)) || String(a.userHandle || a.userKey).localeCompare(String(b.userHandle || b.userKey)));
+    const followers = followerKeys
+      .map((key)=>scoreCandidate(key, 'followers'))
+      .filter((item)=>item.score >= 30 || item.reasons.length >= 3)
+      .sort((a, b)=> (b.score - a.score) || ((a.followerCount ?? Infinity) - (b.followerCount ?? Infinity)) || String(a.userHandle || a.userKey).localeCompare(String(b.userHandle || b.userKey)));
+    return {
+      summary: {
+        followersCaptured: followerKeys.length,
+        followingCaptured: followingKeys.length,
+        mutualCount: mutualSet.size,
+        nonMutualFollowingCount: followingKeys.length - mutualSet.size,
+        zeroSignalFollowingCount: following.filter((item)=>item.zeroSignal).length,
+        unfollowLikelyCount: following.filter((item)=>item.score >= 60).length,
+        lowSignalFollowersCount: followers.filter((item)=>item.score >= 55).length
+      },
+      following,
+      followers
     };
   }
   function resolveCanonicalUserKey(metrics, userKey, user = null){
@@ -2296,8 +2542,9 @@
       const hasPosts = posts && Object.keys(posts).length > 0;
       const hasFollowers = Array.isArray(user?.followers) && user.followers.length > 0;
       const hasCameos = Array.isArray(user?.cameos) && user.cameos.length > 0;
+      const hasRelationshipGraph = relationshipGraphHasData(user?.relationshipGraph);
       const keepForCharacter = isCharacterId(user?.id);
-      if (!hasPosts && !hasFollowers && !hasCameos && !keepForCharacter){
+      if (!hasPosts && !hasFollowers && !hasCameos && !hasRelationshipGraph && !keepForCharacter){
         delete users[key];
         removed++;
       }
@@ -2865,6 +3112,791 @@
     } else {
       link.setAttribute('aria-disabled', 'true');
     }
+  }
+
+  const CLEANUP_PLANNER_DEFAULTS = Object.freeze({
+    maxFollowers: 200,
+    minPosts: 12,
+    minLikesReceived: 120,
+    staleDays: 45,
+  });
+
+  function getCleanupPlannerOptions() {
+    const maxFollowers = Math.max(0, Number($('#cleanupMaxFollowers')?.value) || CLEANUP_PLANNER_DEFAULTS.maxFollowers);
+    const minPosts = Math.max(0, Number($('#cleanupMinPosts')?.value) || CLEANUP_PLANNER_DEFAULTS.minPosts);
+    const minLikesReceived = Math.max(0, Number($('#cleanupMinLikesReceived')?.value) || CLEANUP_PLANNER_DEFAULTS.minLikesReceived);
+    const staleDays = Math.max(0, Number($('#cleanupStaleDays')?.value) || CLEANUP_PLANNER_DEFAULTS.staleDays);
+    return {
+      maxFollowers,
+      minPosts,
+      minLikesReceived,
+      staleDays,
+    };
+  }
+
+  function getCleanupScoreThreshold(kind, bucket) {
+    if (kind === 'followers') {
+      return bucket === 'review' ? 35 : 55;
+    }
+    return bucket === 'review' ? 40 : 60;
+  }
+
+  function resetCleanupPanelState(kind = null) {
+    const apply = (panelKind) => {
+      if (!cleanupPanelState[panelKind]) return;
+      const pageSize = Number(cleanupPanelState[panelKind].pageSize) || CLEANUP_PANEL_FILTER_DEFAULTS.pageSize;
+      Object.assign(cleanupPanelState[panelKind], {
+        ...CLEANUP_PANEL_FILTER_DEFAULTS,
+        pageSize,
+        ...(panelKind === 'following' ? { preset: 'all' } : {}),
+      });
+    };
+    if (kind) {
+      apply(kind);
+      return;
+    }
+    CLEANUP_PANEL_KINDS.forEach(apply);
+  }
+
+  function getCleanupPanelElements(kind) {
+    const suffix = kind === 'followers' ? 'Followers' : 'Following';
+    return {
+      meta: $(`#cleanup${suffix}PanelMeta`),
+      list: $(`#cleanup${suffix}List`),
+      note: $(`#cleanup${suffix}ActionNote`),
+      prev: $(`#cleanup${suffix}Prev`),
+      next: $(`#cleanup${suffix}Next`),
+      pagination: $(`#cleanup${suffix}Pagination`),
+      search: $(`#cleanup${suffix}Search`),
+      status: $(`#cleanup${suffix}Status`),
+      reason: $(`#cleanup${suffix}Reason`),
+      sort: $(`#cleanup${suffix}Sort`),
+      pageSize: $(`#cleanup${suffix}PageSize`),
+    };
+  }
+
+  function normalizeCleanupSearch(value) {
+    return typeof value === 'string' ? value.trim().toLowerCase() : '';
+  }
+
+  function cleanupItemMatchesSearch(item, query) {
+    if (!query) return true;
+    const haystack = [
+      item?.userHandle,
+      item?.displayName,
+      item?.userKey,
+    ].filter(Boolean).join(' ').toLowerCase();
+    return haystack.includes(query);
+  }
+
+  function cleanupItemMatchesStatus(item, status, kind) {
+    if (!item) return false;
+    const normalized = String(status || 'all').toLowerCase();
+    if (normalized === 'all') return true;
+    const actionableThreshold = getCleanupScoreThreshold(kind, 'actionable');
+    const reviewThreshold = getCleanupScoreThreshold(kind, 'review');
+    if (normalized === 'actionable') return item.score >= actionableThreshold;
+    if (normalized === 'review') return item.score >= reviewThreshold && item.score < actionableThreshold;
+    if (normalized === 'low_priority') return item.score < reviewThreshold;
+    return true;
+  }
+
+  function cleanupItemMatchesReason(item, reason) {
+    if (!item) return false;
+    const normalized = String(reason || 'all').toLowerCase();
+    if (normalized === 'all') return true;
+    if (normalized === 'smart_unfollow') {
+      return !!item.nonMutual && (!!item.zeroSignal || (!!item.lowFollowers && (!!item.lowPosts || !!item.lowLikes || !!item.inactive)));
+    }
+    if (normalized === 'non_mutual') return !!item.nonMutual;
+    if (normalized === 'low_followers') return !!item.lowFollowers;
+    if (normalized === 'low_posts') return !!item.lowPosts;
+    if (normalized === 'low_likes') return !!item.lowLikes;
+    if (normalized === 'inactive') return !!item.inactive;
+    if (normalized === 'zero_signal') return !!item.zeroSignal;
+    if (normalized === 'verified') return !!item.verified;
+    return true;
+  }
+
+  function compareCleanupPlannerItems(a, b, sortKey) {
+    const normalized = String(sortKey || 'score_desc').toLowerCase();
+    if (normalized === 'followers_asc') {
+      return ((a?.followerCount ?? Infinity) - (b?.followerCount ?? Infinity))
+        || ((b?.score ?? 0) - (a?.score ?? 0))
+        || String(a?.userHandle || a?.userKey || '').localeCompare(String(b?.userHandle || b?.userKey || ''));
+    }
+    if (normalized === 'posts_asc') {
+      return ((a?.postCount ?? Infinity) - (b?.postCount ?? Infinity))
+        || ((b?.score ?? 0) - (a?.score ?? 0))
+        || String(a?.userHandle || a?.userKey || '').localeCompare(String(b?.userHandle || b?.userKey || ''));
+    }
+    if (normalized === 'likes_asc') {
+      return ((a?.likesReceivedCount ?? Infinity) - (b?.likesReceivedCount ?? Infinity))
+        || ((b?.score ?? 0) - (a?.score ?? 0))
+        || String(a?.userHandle || a?.userKey || '').localeCompare(String(b?.userHandle || b?.userKey || ''));
+    }
+    if (normalized === 'stale_desc') {
+      return ((b?.inactiveDays ?? -1) - (a?.inactiveDays ?? -1))
+        || ((b?.score ?? 0) - (a?.score ?? 0))
+        || String(a?.userHandle || a?.userKey || '').localeCompare(String(b?.userHandle || b?.userKey || ''));
+    }
+    if (normalized === 'handle_asc') {
+      return String(a?.userHandle || a?.userKey || '').localeCompare(String(b?.userHandle || b?.userKey || ''))
+        || ((b?.score ?? 0) - (a?.score ?? 0));
+    }
+    return ((b?.score ?? 0) - (a?.score ?? 0))
+      || ((a?.followerCount ?? Infinity) - (b?.followerCount ?? Infinity))
+      || String(a?.userHandle || a?.userKey || '').localeCompare(String(b?.userHandle || b?.userKey || ''));
+  }
+
+  function filterCleanupPlannerItems(items, panelState, kind) {
+    const list = Array.isArray(items) ? items.slice() : [];
+    const search = normalizeCleanupSearch(panelState?.search);
+    const status = panelState?.status || 'all';
+    const reason = panelState?.reason || 'all';
+    const sort = panelState?.sort || 'score_desc';
+    return list
+      .filter((item) => cleanupItemMatchesSearch(item, search))
+      .filter((item) => cleanupItemMatchesStatus(item, status, kind))
+      .filter((item) => cleanupItemMatchesReason(item, reason))
+      .sort((a, b) => compareCleanupPlannerItems(a, b, sort));
+  }
+
+  function paginateCleanupPlannerItems(items, page, pageSize) {
+    const totalItems = Array.isArray(items) ? items.length : 0;
+    const safePageSize = Math.max(1, Number(pageSize) || CLEANUP_PANEL_FILTER_DEFAULTS.pageSize);
+    const totalPages = Math.max(1, Math.ceil(totalItems / safePageSize));
+    const safePage = Math.min(totalPages, Math.max(1, Number(page) || 1));
+    const start = (safePage - 1) * safePageSize;
+    return {
+      totalItems,
+      totalPages,
+      page: safePage,
+      pageSize: safePageSize,
+      items: Array.isArray(items) ? items.slice(start, start + safePageSize) : [],
+    };
+  }
+
+  function clearCleanupPlannerList(el, emptyText) {
+    if (!el) return;
+    el.textContent = '';
+    const empty = document.createElement('div');
+    empty.className = 'cleanup-empty';
+    empty.textContent = emptyText;
+    el.appendChild(empty);
+  }
+
+  function getCleanupPlanSelectedFollowingItems() {
+    const following = Array.isArray(cleanupPlannerContextPlan?.following) ? cleanupPlannerContextPlan.following : [];
+    return following.filter((item) => cleanupSelectedFollowingKeys.has(item.userKey));
+  }
+
+  function getCleanupZeroSignalFollowingItems() {
+    const following = Array.isArray(cleanupPlannerContextPlan?.following) ? cleanupPlannerContextPlan.following : [];
+    return following.filter((item) => item?.selectable && item.zeroSignal);
+  }
+
+  function getCleanupFollowingPresetFilterState(presetId) {
+    const normalized = String(presetId || 'all').toLowerCase();
+    if (normalized === 'smart_unfollow') {
+      return { preset: 'smart_unfollow', search: '', status: 'actionable', reason: 'smart_unfollow', sort: 'score_desc' };
+    }
+    if (normalized === 'zero_signal') {
+      return { preset: 'zero_signal', search: '', status: 'actionable', reason: 'zero_signal', sort: 'score_desc' };
+    }
+    if (normalized === 'non_mutual') {
+      return { preset: 'non_mutual', search: '', status: 'actionable', reason: 'non_mutual', sort: 'score_desc' };
+    }
+    if (normalized === 'inactive') {
+      return { preset: 'inactive', search: '', status: 'actionable', reason: 'inactive', sort: 'stale_desc' };
+    }
+    if (normalized === 'low_likes') {
+      return { preset: 'low_likes', search: '', status: 'actionable', reason: 'low_likes', sort: 'likes_asc' };
+    }
+    return { preset: 'all', search: '', status: 'all', reason: 'all', sort: 'score_desc' };
+  }
+
+  function getCleanupFollowingPresetCount(presetId) {
+    const items = Array.isArray(cleanupPlannerContextPlan?.following) ? cleanupPlannerContextPlan.following : [];
+    const state = getCleanupFollowingPresetFilterState(presetId);
+    return filterCleanupPlannerItems(items, state, 'following').length;
+  }
+
+  function renderCleanupFollowingQuickFilters() {
+    const currentPreset = String(cleanupPanelState.following?.preset || 'custom').toLowerCase();
+    for (const preset of CLEANUP_FOLLOWING_PRESET_DEFS) {
+      const button = document.querySelector(`[data-cleanup-preset="${preset.id}"]`);
+      if (!button) continue;
+      const count = getCleanupFollowingPresetCount(preset.id);
+      button.textContent = `${preset.label}${count ? ` (${fmtK2OrInt(count)})` : ''}`;
+      button.classList.toggle('active', currentPreset === preset.id);
+      button.disabled = cleanupBulkActionBusy || (!count && preset.id !== 'all');
+    }
+  }
+
+  function applyCleanupFollowingPreset(presetId) {
+    const nextState = cleanupPanelState.following;
+    if (!nextState) return;
+    const presetState = getCleanupFollowingPresetFilterState(presetId);
+    Object.assign(nextState, presetState, {
+      page: 1,
+      pageSize: Number(nextState.pageSize) || CLEANUP_PANEL_FILTER_DEFAULTS.pageSize,
+    });
+    cleanupBulkActionMessage = '';
+    cleanupBulkActionTone = 'muted';
+    renderCleanupPlannerPanels();
+  }
+
+  function syncCleanupPanelControls(kind) {
+    const panel = getCleanupPanelElements(kind);
+    const state = cleanupPanelState[kind];
+    if (!panel || !state) return;
+    if (panel.search && panel.search.value !== state.search) panel.search.value = state.search;
+    if (panel.status && panel.status.value !== state.status) panel.status.value = state.status;
+    if (panel.reason && panel.reason.value !== state.reason) panel.reason.value = state.reason;
+    if (panel.sort && panel.sort.value !== state.sort) panel.sort.value = state.sort;
+    if (panel.pageSize && String(panel.pageSize.value) !== String(state.pageSize)) panel.pageSize.value = String(state.pageSize);
+  }
+
+  function setCleanupBulkActionMessage(message, tone = 'muted') {
+    cleanupBulkActionMessage = message || '';
+    cleanupBulkActionTone = tone || 'muted';
+    const note = getCleanupPanelElements('following').note;
+    if (!note) return;
+    note.textContent = cleanupBulkActionMessage || CLEANUP_ZERO_SIGNAL_HINT;
+    note.classList.remove('cleanup-panel-note--success', 'cleanup-panel-note--warn', 'cleanup-panel-note--danger');
+    if (cleanupBulkActionTone === 'success') note.classList.add('cleanup-panel-note--success');
+    else if (cleanupBulkActionTone === 'warn') note.classList.add('cleanup-panel-note--warn');
+    else if (cleanupBulkActionTone === 'danger') note.classList.add('cleanup-panel-note--danger');
+  }
+
+  function renderCleanupPlannerItems(kind, listEl, items, emptyText) {
+    if (!listEl) return;
+    listEl.textContent = '';
+    if (!Array.isArray(items) || !items.length) {
+      clearCleanupPlannerList(listEl, emptyText);
+      return;
+    }
+    const allowSelection = kind === 'following';
+    const frag = document.createDocumentFragment();
+    for (const item of items) {
+      const row = document.createElement('div');
+      row.className = `cleanup-item${allowSelection ? ' cleanup-item--selectable' : ''}`;
+
+      const head = document.createElement('div');
+      head.className = 'cleanup-item-head';
+
+      const headMain = document.createElement('div');
+      headMain.className = 'cleanup-item-head-main';
+
+      if (allowSelection) {
+        const selector = document.createElement('label');
+        selector.className = 'cleanup-item-select';
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = cleanupSelectedFollowingKeys.has(item.userKey);
+        checkbox.disabled = cleanupBulkActionBusy || !item.selectable;
+        checkbox.setAttribute('aria-label', item.userHandle ? `Select @${item.userHandle}` : `Select ${item.userKey}`);
+        checkbox.addEventListener('change', () => {
+          if (checkbox.checked) cleanupSelectedFollowingKeys.add(item.userKey);
+          else cleanupSelectedFollowingKeys.delete(item.userKey);
+          renderCleanupPlannerPanels();
+        });
+        selector.appendChild(checkbox);
+        headMain.appendChild(selector);
+      }
+
+      const identity = document.createElement('div');
+      identity.className = 'cleanup-item-identity';
+
+      const link = document.createElement('a');
+      link.className = 'cleanup-item-link';
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      link.href = item.permalink || (item.userHandle ? `${SITE_ORIGIN}/profile/${encodeURIComponent(item.userHandle)}` : '#');
+      link.textContent = item.userHandle ? `@${item.userHandle}` : (item.displayName || item.userKey);
+      identity.appendChild(link);
+
+      if (item.displayName && item.displayName !== item.userHandle) {
+        const name = document.createElement('div');
+        name.className = 'cleanup-item-name';
+        name.textContent = item.displayName;
+        identity.appendChild(name);
+      }
+
+      headMain.appendChild(identity);
+
+      const score = document.createElement('div');
+      score.className = 'cleanup-item-score';
+      score.textContent = `Score ${item.score}`;
+
+      head.appendChild(headMain);
+      head.appendChild(score);
+
+      const meta = document.createElement('div');
+      meta.className = 'cleanup-item-meta';
+      const metaBits = [];
+      if (item.followerCount != null) metaBits.push(`${fmtK2OrInt(item.followerCount)} followers`);
+      if (item.postCount != null) metaBits.push(`${fmtK2OrInt(item.postCount)} posts`);
+      if (item.likesReceivedCount != null) metaBits.push(`${fmtK2OrInt(item.likesReceivedCount)} likes received`);
+      if (item.inactiveDays != null) metaBits.push(item.inactiveDays > 0 ? `${item.inactiveDays}d since update` : 'active recently');
+      meta.textContent = metaBits.join(' • ');
+
+      const badges = document.createElement('div');
+      badges.className = 'cleanup-item-badges';
+      for (const reason of item.reasons || []) {
+        const badge = document.createElement('span');
+        badge.className = `cleanup-badge cleanup-badge--${reason.tone || 'soft'}`;
+        badge.textContent = reason.label;
+        badges.appendChild(badge);
+      }
+
+      const recommendation = document.createElement('div');
+      recommendation.className = 'cleanup-item-recommendation';
+      recommendation.textContent = item.recommendation;
+
+      row.appendChild(head);
+      row.appendChild(meta);
+      if (badges.childNodes.length) row.appendChild(badges);
+      row.appendChild(recommendation);
+
+      if (allowSelection) {
+        const actions = document.createElement('div');
+        actions.className = 'cleanup-item-actions';
+        const note = document.createElement('div');
+        note.className = 'cleanup-item-action-note';
+        note.textContent = item.nonMutual ? 'Non-mutual following candidate' : 'Following account';
+        actions.appendChild(note);
+        row.appendChild(actions);
+      }
+
+      frag.appendChild(row);
+    }
+    listEl.appendChild(frag);
+  }
+
+  function renderCleanupPlannerPanel(kind, items, emptyText) {
+    const panel = getCleanupPanelElements(kind);
+    if (!panel.list) return;
+    syncCleanupPanelControls(kind);
+    const filtered = filterCleanupPlannerItems(items, cleanupPanelState[kind], kind);
+    const pagination = paginateCleanupPlannerItems(filtered, cleanupPanelState[kind].page, cleanupPanelState[kind].pageSize);
+    cleanupPanelState[kind].page = pagination.page;
+
+    if (panel.meta) {
+      const selectedText = kind === 'following'
+        ? ` • ${fmtK2OrInt(getCleanupPlanSelectedFollowingItems().length)} selected`
+        : '';
+      panel.meta.textContent = `${fmtK2OrInt(filtered.length)} matches of ${fmtK2OrInt(Array.isArray(items) ? items.length : 0)}${selectedText}`;
+    }
+    if (panel.pagination) {
+      panel.pagination.textContent = `Page ${pagination.page} of ${pagination.totalPages}`;
+    }
+    if (panel.prev) panel.prev.disabled = pagination.page <= 1;
+    if (panel.next) panel.next.disabled = pagination.page >= pagination.totalPages;
+
+    renderCleanupPlannerItems(kind, panel.list, pagination.items, emptyText);
+  }
+
+  function renderCleanupPlannerPanels() {
+    const followingItems = Array.isArray(cleanupPlannerContextPlan?.following) ? cleanupPlannerContextPlan.following : [];
+    const followerItems = Array.isArray(cleanupPlannerContextPlan?.followers) ? cleanupPlannerContextPlan.followers : [];
+    cleanupSelectedFollowingKeys.forEach((userKey) => {
+      if (!followingItems.some((item) => item.userKey === userKey)) cleanupSelectedFollowingKeys.delete(userKey);
+    });
+    renderCleanupPlannerPanel('following', followingItems, 'No strong unfollow candidates yet. Try tightening the thresholds or collecting more Following rows.');
+    renderCleanupPlannerPanel('followers', followerItems, 'No low-signal followers surfaced yet. This list is review-only until follower removal is wired safely.');
+    renderCleanupFollowingQuickFilters();
+    const followingPanel = getCleanupPanelElements('following');
+    const selectedCount = getCleanupPlanSelectedFollowingItems().length;
+    const zeroSignalCount = getCleanupZeroSignalFollowingItems().length;
+    if (followingPanel.note && !cleanupBulkActionMessage) {
+      followingPanel.note.textContent = selectedCount
+        ? `${fmtK2OrInt(selectedCount)} account${selectedCount === 1 ? '' : 's'} selected. Bulk unfollow uses your live Sora tab and the native Following buttons.`
+        : CLEANUP_ZERO_SIGNAL_HINT;
+      followingPanel.note.classList.remove('cleanup-panel-note--success', 'cleanup-panel-note--warn', 'cleanup-panel-note--danger');
+    }
+    const zeroSignalBtn = $('#cleanupSelectFollowingZeroSignal');
+    if (zeroSignalBtn) {
+      zeroSignalBtn.disabled = cleanupBulkActionBusy || zeroSignalCount === 0;
+      zeroSignalBtn.title = zeroSignalCount
+        ? `Select all ${fmtK2OrInt(zeroSignalCount)} non-mutual follows with 0 followers, 0 posts, 0 likes, and stale activity.`
+        : 'No zero-signal following accounts match the current graph.';
+    }
+    const unfollowBtn = $('#cleanupUnfollowSelected');
+    if (unfollowBtn) unfollowBtn.disabled = cleanupBulkActionBusy || selectedCount === 0;
+  }
+
+  function updateCleanupPlanner(userKey, user) {
+    const note = $('#cleanupPlannerNote');
+    const followersCaptured = $('#cleanupFollowersCaptured');
+    const followingCaptured = $('#cleanupFollowingCaptured');
+    const mutualCaptured = $('#cleanupMutualCaptured');
+    const likelyCount = $('#cleanupLikelyCount');
+    const followerReviewCount = $('#cleanupFollowerReviewCount');
+    const followingList = $('#cleanupFollowingList');
+    const followersList = $('#cleanupFollowersList');
+    if (!note || !followersCaptured || !followingCaptured || !mutualCaptured || !likelyCount || !followerReviewCount || !followingList || !followersList) return;
+
+    const contextChanged = cleanupPlannerContextKey !== userKey;
+    cleanupPlannerContextKey = userKey || null;
+    cleanupPlannerContextUser = user || null;
+    cleanupPlannerContextPlan = null;
+    if (contextChanged) {
+      cleanupSelectedFollowingKeys.clear();
+      resetCleanupPanelState();
+      cleanupBulkActionMessage = '';
+      cleanupBulkActionTone = 'muted';
+    }
+
+    if (!userKey || !user || isVirtualUserKey(userKey)) {
+      cleanupPlannerContextPlan = { summary: {}, following: [], followers: [] };
+      note.textContent = 'Open a profile on Sora, then open the Followers or Following modal to collect relationship data for cleanup planning.';
+      followersCaptured.textContent = '0';
+      followingCaptured.textContent = '0';
+      mutualCaptured.textContent = '0';
+      likelyCount.textContent = '0';
+      followerReviewCount.textContent = '0';
+      setCleanupBulkActionMessage('', 'muted');
+      renderCleanupPlannerPanels();
+      return;
+    }
+
+    const plan = buildCleanupPlannerModel(user, getCleanupPlannerOptions());
+    cleanupPlannerContextPlan = plan;
+    followersCaptured.textContent = fmtK2OrInt(plan.summary.followersCaptured);
+    followingCaptured.textContent = fmtK2OrInt(plan.summary.followingCaptured);
+    mutualCaptured.textContent = fmtK2OrInt(plan.summary.mutualCount);
+    likelyCount.textContent = fmtK2OrInt(plan.summary.unfollowLikelyCount);
+    followerReviewCount.textContent = fmtK2OrInt(plan.summary.lowSignalFollowersCount);
+
+    const label = getGatherDisplayName(userKey, user);
+    if (plan.summary.followersCaptured === 0 && plan.summary.followingCaptured === 0) {
+      note.textContent = `No cleanup graph captured for ${label} yet. Open the Followers or Following modal on Sora and scroll through accounts to collect it.`;
+    } else if (plan.summary.followingCaptured === 0) {
+      note.textContent = `Captured ${fmtK2OrInt(plan.summary.followersCaptured)} followers for ${label}. Open the Following tab too if you want unfollow recommendations.`;
+    } else if (plan.summary.followersCaptured === 0) {
+      note.textContent = `Captured ${fmtK2OrInt(plan.summary.followingCaptured)} following accounts for ${label}. Open the Followers tab too to improve mutual detection.`;
+    } else {
+      note.textContent = `Captured ${fmtK2OrInt(plan.summary.followersCaptured)} followers and ${fmtK2OrInt(plan.summary.followingCaptured)} following accounts for ${label}.`;
+    }
+    renderCleanupPlannerPanels();
+  }
+
+  function getCleanupPanelFilteredItems(kind) {
+    const items = Array.isArray(cleanupPlannerContextPlan?.[kind]) ? cleanupPlannerContextPlan[kind] : [];
+    return filterCleanupPlannerItems(items, cleanupPanelState[kind], kind);
+  }
+
+  function getCleanupPanelPageItems(kind) {
+    const filtered = getCleanupPanelFilteredItems(kind);
+    return paginateCleanupPlannerItems(filtered, cleanupPanelState[kind].page, cleanupPanelState[kind].pageSize).items;
+  }
+
+  function setCleanupPanelPage(kind, nextPage) {
+    if (!cleanupPanelState[kind]) return;
+    cleanupPanelState[kind].page = Math.max(1, Number(nextPage) || 1);
+    renderCleanupPlannerPanels();
+  }
+
+  function selectCleanupFollowingItems(mode = 'page') {
+    const items = mode === 'filtered' ? getCleanupPanelFilteredItems('following') : getCleanupPanelPageItems('following');
+    for (const item of items) {
+      if (item?.selectable) cleanupSelectedFollowingKeys.add(item.userKey);
+    }
+    cleanupBulkActionMessage = '';
+    cleanupBulkActionTone = 'muted';
+    renderCleanupPlannerPanels();
+  }
+
+  function selectCleanupZeroSignalFollowingItems() {
+    const items = getCleanupZeroSignalFollowingItems();
+    if (!items.length) {
+      setCleanupBulkActionMessage('No zero-signal following accounts are available to select yet.', 'warn');
+      renderCleanupPlannerPanels();
+      return;
+    }
+    for (const item of items) cleanupSelectedFollowingKeys.add(item.userKey);
+    setCleanupBulkActionMessage(
+      `Selected ${fmtK2OrInt(items.length)} zero-signal account${items.length === 1 ? '' : 's'} with 0 followers, 0 posts, 0 likes, and stale activity.`,
+      'warn'
+    );
+    renderCleanupPlannerPanels();
+  }
+
+  function clearCleanupFollowingSelection() {
+    cleanupSelectedFollowingKeys.clear();
+    cleanupBulkActionMessage = '';
+    cleanupBulkActionTone = 'muted';
+    renderCleanupPlannerPanels();
+  }
+
+  function sendCleanupTabAction(message) {
+    return new Promise((resolve) => {
+      try {
+        // Let the background worker choose the best Sora tab/profile target instead
+        // of guessing from the first matching tab in the dashboard page.
+        chrome.runtime.sendMessage(message, (response) => {
+          if (chrome.runtime.lastError) {
+            resolve({ ok: false, error: chrome.runtime.lastError.message || 'Could not start the cleanup request.' });
+            return;
+          }
+          resolve(response && typeof response === 'object' ? response : { ok: false, error: 'No response from the cleanup request.' });
+        });
+      } catch (err) {
+        resolve({ ok: false, error: err?.message || 'Could not send the cleanup request.' });
+      }
+    });
+  }
+
+  function createCleanupBulkResultWaiter(requestId, timeoutMs = 180000) {
+    let done = false;
+    let timer = null;
+    let onMessage = null;
+    let resolvePromise = null;
+    const finish = (payload) => {
+      if (done) return;
+      done = true;
+      try { clearTimeout(timer); } catch {}
+      if (onMessage) {
+        try { chrome.runtime.onMessage.removeListener(onMessage); } catch {}
+      }
+      if (typeof resolvePromise === 'function') {
+        resolvePromise(payload && typeof payload === 'object' ? payload : { ok: false, error: 'No bulk unfollow result payload.' });
+      }
+    };
+    const promise = new Promise((resolve) => {
+      resolvePromise = resolve;
+      onMessage = (message) => {
+        if (!message || message.action !== 'cleanup_bulk_unfollow_result' || message.requestId !== requestId) return false;
+        finish(message.payload);
+        return false;
+      };
+      try {
+        chrome.runtime.onMessage.addListener(onMessage);
+      } catch (err) {
+        finish({ ok: false, error: err?.message || 'Could not listen for the cleanup result.' });
+        return;
+      }
+      timer = setTimeout(() => {
+        finish({ ok: false, error: 'Timed out waiting for Sora to finish the bulk unfollow action.' });
+      }, Math.max(1000, Number(timeoutMs) || 0));
+    });
+    return {
+      promise,
+      cancel(payload) {
+        finish(payload || { ok: false, error: 'Bulk unfollow did not finish.' });
+      },
+    };
+  }
+
+  async function runCleanupBulkUnfollow() {
+    if (cleanupBulkActionBusy) return;
+    const selectedItems = getCleanupPlanSelectedFollowingItems().filter((item) => item?.selectable);
+    if (!selectedItems.length) {
+      showToast('Select at least one following account first.');
+      return;
+    }
+    if (selectedItems.length > CLEANUP_BULK_UNFOLLOW_LIMIT) {
+      setCleanupBulkActionMessage(`Select ${CLEANUP_BULK_UNFOLLOW_LIMIT} accounts or fewer per bulk unfollow run.`, 'warn');
+      renderCleanupPlannerPanels();
+      return;
+    }
+    const profileHandle = getProfileHandleFromKey(cleanupPlannerContextKey, cleanupPlannerContextUser);
+    const label = getGatherDisplayName(cleanupPlannerContextKey, cleanupPlannerContextUser);
+    const confirmText = `Unfollow ${selectedItems.length} selected account${selectedItems.length === 1 ? '' : 's'} for ${label}?\n\nThis uses your live Sora tab and the native Following buttons.`;
+    if (!confirm(confirmText)) return;
+
+    cleanupBulkActionBusy = true;
+    setCleanupBulkActionMessage(`Preparing to unfollow ${selectedItems.length} selected account${selectedItems.length === 1 ? '' : 's'}...`, 'warn');
+    renderCleanupPlannerPanels();
+
+    const requestId = `cleanup:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`;
+    const waiter = createCleanupBulkResultWaiter(requestId);
+    const startResponse = await sendCleanupTabAction({
+      action: 'cleanup_bulk_unfollow',
+      requestId,
+      profileHandle,
+      userKey: cleanupPlannerContextKey,
+      targets: selectedItems.map((item) => ({
+        userKey: item.userKey,
+        userHandle: item.userHandle,
+        permalink: item.permalink || null,
+      })),
+    });
+
+    if (!startResponse?.ok) {
+      waiter.cancel({ ok: false, error: startResponse?.error || 'Bulk unfollow failed to start.' });
+      cleanupBulkActionBusy = false;
+      setCleanupBulkActionMessage(startResponse?.error || 'Bulk unfollow failed.', 'danger');
+      renderCleanupPlannerPanels();
+      return;
+    }
+
+    if (startResponse?.started !== true) {
+      waiter.cancel({ ok: false, error: 'Bulk unfollow did not start.' });
+      cleanupBulkActionBusy = false;
+      setCleanupBulkActionMessage('Bulk unfollow did not start.', 'danger');
+      renderCleanupPlannerPanels();
+      return;
+    }
+
+    const response = await waiter.promise;
+    cleanupBulkActionBusy = false;
+    if (!response?.ok) {
+      setCleanupBulkActionMessage(response?.error || 'Bulk unfollow failed.', 'danger');
+      renderCleanupPlannerPanels();
+      return;
+    }
+
+    const unfollowed = Math.max(0, Number(response?.unfollowed) || 0);
+    const skipped = Math.max(0, Number(response?.skipped) || 0);
+    const missing = Math.max(0, Number(response?.notFound) || 0);
+    cleanupSelectedFollowingKeys.clear();
+    const message = `Unfollowed ${fmtK2OrInt(unfollowed)} account${unfollowed === 1 ? '' : 's'}${skipped ? ` • ${fmtK2OrInt(skipped)} skipped` : ''}${missing ? ` • ${fmtK2OrInt(missing)} not found` : ''}. Harvest Following again to refresh the graph.`;
+    setCleanupBulkActionMessage(message, missing ? 'warn' : 'success');
+    renderCleanupPlannerPanels();
+    showToast(`Unfollowed ${fmtK2OrInt(unfollowed)} account${unfollowed === 1 ? '' : 's'}.`);
+  }
+
+  function bindCleanupPlannerControls() {
+    for (const kind of CLEANUP_PANEL_KINDS) {
+      const panel = getCleanupPanelElements(kind);
+      if (!panel || !cleanupPanelState[kind]) continue;
+      const bindValue = (el, key, parser = (value) => value) => {
+        if (!el || el.dataset.cleanupBound === '1') return;
+        el.dataset.cleanupBound = '1';
+        el.addEventListener('input', () => {
+          const nextState = cleanupPanelState[kind];
+          if (!nextState) return;
+          nextState[key] = parser(el.value);
+          if (kind === 'following' && key !== 'pageSize') nextState.preset = 'custom';
+          nextState.page = 1;
+          cleanupBulkActionMessage = '';
+          cleanupBulkActionTone = 'muted';
+          renderCleanupPlannerPanels();
+        });
+        el.addEventListener('change', () => {
+          const nextState = cleanupPanelState[kind];
+          if (!nextState) return;
+          nextState[key] = parser(el.value);
+          if (kind === 'following' && key !== 'pageSize') nextState.preset = 'custom';
+          nextState.page = 1;
+          cleanupBulkActionMessage = '';
+          cleanupBulkActionTone = 'muted';
+          renderCleanupPlannerPanels();
+        });
+      };
+      bindValue(panel.search, 'search', (value) => String(value || ''));
+      bindValue(panel.status, 'status', (value) => String(value || 'all'));
+      bindValue(panel.reason, 'reason', (value) => String(value || 'all'));
+      bindValue(panel.sort, 'sort', (value) => String(value || 'score_desc'));
+      bindValue(panel.pageSize, 'pageSize', (value) => Math.max(1, Number(value) || CLEANUP_PANEL_FILTER_DEFAULTS.pageSize));
+      if (panel.prev && panel.prev.dataset.cleanupBound !== '1') {
+        panel.prev.dataset.cleanupBound = '1';
+        panel.prev.addEventListener('click', () => setCleanupPanelPage(kind, cleanupPanelState[kind].page - 1));
+      }
+      if (panel.next && panel.next.dataset.cleanupBound !== '1') {
+        panel.next.dataset.cleanupBound = '1';
+        panel.next.addEventListener('click', () => setCleanupPanelPage(kind, cleanupPanelState[kind].page + 1));
+      }
+    }
+
+    const selectPageBtn = $('#cleanupSelectFollowingPage');
+    if (selectPageBtn && selectPageBtn.dataset.cleanupBound !== '1') {
+      selectPageBtn.dataset.cleanupBound = '1';
+      selectPageBtn.addEventListener('click', () => selectCleanupFollowingItems('page'));
+    }
+    const selectFilteredBtn = $('#cleanupSelectFollowingFiltered');
+    if (selectFilteredBtn && selectFilteredBtn.dataset.cleanupBound !== '1') {
+      selectFilteredBtn.dataset.cleanupBound = '1';
+      selectFilteredBtn.addEventListener('click', () => selectCleanupFollowingItems('filtered'));
+    }
+    for (const button of document.querySelectorAll('[data-cleanup-preset]')) {
+      if (button.dataset.cleanupBound === '1') continue;
+      button.dataset.cleanupBound = '1';
+      button.addEventListener('click', () => applyCleanupFollowingPreset(button.dataset.cleanupPreset || 'all'));
+    }
+    const selectZeroSignalBtn = $('#cleanupSelectFollowingZeroSignal');
+    if (selectZeroSignalBtn && selectZeroSignalBtn.dataset.cleanupBound !== '1') {
+      selectZeroSignalBtn.dataset.cleanupBound = '1';
+      selectZeroSignalBtn.addEventListener('click', selectCleanupZeroSignalFollowingItems);
+    }
+    const clearBtn = $('#cleanupClearFollowingSelection');
+    if (clearBtn && clearBtn.dataset.cleanupBound !== '1') {
+      clearBtn.dataset.cleanupBound = '1';
+      clearBtn.addEventListener('click', clearCleanupFollowingSelection);
+    }
+    const unfollowBtn = $('#cleanupUnfollowSelected');
+    if (unfollowBtn && unfollowBtn.dataset.cleanupBound !== '1') {
+      unfollowBtn.dataset.cleanupBound = '1';
+      unfollowBtn.addEventListener('click', () => {
+        runCleanupBulkUnfollow().catch((err) => {
+          cleanupBulkActionBusy = false;
+          setCleanupBulkActionMessage(err?.message || 'Bulk unfollow failed.', 'danger');
+          renderCleanupPlannerPanels();
+        });
+      });
+    }
+  }
+
+  function getStoredDashboardWorkspace() {
+    try {
+      const value = String(localStorage.getItem(DASHBOARD_WORKSPACE_STORAGE_KEY) || '').trim().toLowerCase();
+      return value === 'cleanup' ? 'cleanup' : 'overview';
+    } catch {
+      return 'overview';
+    }
+  }
+
+  function setDashboardWorkspace(workspace) {
+    const nextWorkspace = workspace === 'cleanup' ? 'cleanup' : 'overview';
+    activeDashboardWorkspace = nextWorkspace;
+    try {
+      localStorage.setItem(DASHBOARD_WORKSPACE_STORAGE_KEY, nextWorkspace);
+    } catch {}
+    document.body.dataset.dashboardWorkspace = nextWorkspace;
+    for (const button of document.querySelectorAll('[data-workspace-target]')) {
+      const isActive = button?.dataset?.workspaceTarget === nextWorkspace;
+      button.classList.toggle('active', !!isActive);
+      button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      button.tabIndex = isActive ? 0 : -1;
+    }
+    for (const panel of document.querySelectorAll('[data-workspace-panel]')) {
+      const isActive = panel?.dataset?.workspacePanel === nextWorkspace;
+      panel.classList.toggle('is-active', !!isActive);
+      panel.hidden = !isActive;
+    }
+  }
+
+  function initDashboardWorkspaces() {
+    const content = document.querySelector('.content');
+    const shell = document.querySelector('.dashboard-workspaces-shell');
+    const overviewPanel = $('#dashboardOverviewWorkspace');
+    const cleanupPanel = $('#dashboardCleanupWorkspace');
+    const cleanupSection = $('#cleanupPlannerSection');
+    if (!content || !shell || !overviewPanel || !cleanupPanel || !cleanupSection) return;
+
+    const directChildren = Array.from(content.children);
+    for (const child of directChildren) {
+      if (child === shell) continue;
+      if (child === cleanupSection) {
+        cleanupPanel.appendChild(child);
+        continue;
+      }
+      overviewPanel.appendChild(child);
+    }
+
+    for (const button of document.querySelectorAll('[data-workspace-target]')) {
+      if (button.dataset.workspaceBound === '1') continue;
+      button.dataset.workspaceBound = '1';
+      button.addEventListener('click', () => {
+        setDashboardWorkspace(button.dataset.workspaceTarget || 'overview');
+      });
+    }
+
+    setDashboardWorkspace(getStoredDashboardWorkspace());
   }
 
   function collectCameoUsernamesFromMetrics(metrics){
@@ -6778,6 +7810,32 @@ function makeTimeChart(canvas, tooltipSelector = '#viewsTooltip', yAxisLabel = '
     hoistChartTooltips();
     hoistToBody($('#purgeConfirmDialog'));
     hoistToBody($('#postPurgeConfirm'));
+    initDashboardWorkspaces();
+    bindCleanupPlannerControls();
+    const cleanupInputBindings = [
+      ['#cleanupMaxFollowers', CLEANUP_PLANNER_DEFAULTS.maxFollowers],
+      ['#cleanupMinPosts', CLEANUP_PLANNER_DEFAULTS.minPosts],
+      ['#cleanupMinLikesReceived', CLEANUP_PLANNER_DEFAULTS.minLikesReceived],
+      ['#cleanupStaleDays', CLEANUP_PLANNER_DEFAULTS.staleDays],
+    ];
+    for (const [selector, fallback] of cleanupInputBindings) {
+      const input = $(selector);
+      if (!input) continue;
+      if (!String(input.value || '').trim()) input.value = String(fallback);
+      input.addEventListener('input', () => {
+        CLEANUP_PANEL_KINDS.forEach((kind) => {
+          if (cleanupPanelState[kind]) cleanupPanelState[kind].page = 1;
+        });
+        cleanupBulkActionMessage = '';
+        cleanupBulkActionTone = 'muted';
+        let selectedUser = resolveUserForKey(metrics, currentUserKey);
+        if (!isMetricsPartial && selectedUser && !isVirtualUserKey(currentUserKey)) {
+          const mergedIdentity = buildMergedIdentityUser(metrics, currentUserKey, selectedUser);
+          selectedUser = mergedIdentity?.user || selectedUser;
+        }
+        updateCleanupPlanner(currentUserKey, selectedUser);
+      });
+    }
     const cached = prefetchedCache !== undefined ? prefetchedCache : loadInstantCache();
     const hasBootCache = !!cached;
     if (cached) {
@@ -9379,13 +10437,14 @@ function makeTimeChart(canvas, tooltipSelector = '#viewsTooltip', yAxisLabel = '
             }
           }
         }
-    if (!user){
-      snapLog('refreshUserUI:noUser', { currentUserKey, snapshotsHydrated, isMetricsPartial });
-      updateMetricsHeader(currentUserKey, null);
-      updateMetricsGatherNote(currentUserKey, null);
-      setListActionActive('showAll');
-      currentVisibilitySource = 'showAll';
-      buildPostsList(null, ()=>getPaletteColor(0), new Set());
+	    if (!user){
+	      snapLog('refreshUserUI:noUser', { currentUserKey, snapshotsHydrated, isMetricsPartial });
+	      updateMetricsHeader(currentUserKey, null);
+	      updateMetricsGatherNote(currentUserKey, null);
+	      updateCleanupPlanner(currentUserKey, null);
+	      setListActionActive('showAll');
+	      currentVisibilitySource = 'showAll';
+	      buildPostsList(null, ()=>getPaletteColor(0), new Set());
       chart.setData([]);
       interactionRateStackedChart.setData([]);
       viewsChart.setData([]);
@@ -9399,11 +10458,12 @@ function makeTimeChart(canvas, tooltipSelector = '#viewsTooltip', yAxisLabel = '
       return;
     }
         // No precompute needed for IR; use latest available remix count only for cards
-        const colorFor = makeColorMap(user);
-        const isTopToday = isTopTodayKey(currentUserKey);
-        updateMetricsHeader(currentUserKey, user);
-        updateMetricsGatherNote(currentUserKey, user);
-        syncIdentityOptionCounts(currentUserKey, user);
+	        const colorFor = makeColorMap(user);
+	        const isTopToday = isTopTodayKey(currentUserKey);
+	        updateMetricsHeader(currentUserKey, user);
+	        updateMetricsGatherNote(currentUserKey, user);
+	        updateCleanupPlanner(currentUserKey, user);
+	        syncIdentityOptionCounts(currentUserKey, user);
         if (!normalizeFilterAction(currentVisibilitySource)) {
           const sessionAction = getSessionFilterAction();
           currentVisibilitySource = sessionAction;

--- a/inject.js
+++ b/inject.js
@@ -51,6 +51,7 @@
   const NF_CREATE_RE = /\/backend\/nf\/create/i;
   const NF_PENDING_V2_RE = /\/backend\/nf\/pending\/v2/i;
   const POST_DETAIL_RE = /\/(backend\/project_[a-z]+\/)?posts?\/[^/]+(\/(tree|children|ancestors|remix_posts|remixes))?(\?|$)/i;
+  const RELATIONSHIP_LIST_RE = /\/backend\/project_[a-z]+\/([^/?#]+)\/(followers|following)\/user_listing(?:\?|$)/i;
 
   // Includes <21h (1260 minutes) plus a final special filter
   const FILTER_STEPS_MIN = [null, 180, 360, 720, 900, 1080, 1260, 'no_remixes'];
@@ -90,6 +91,7 @@
   const lockedPostIds = new Set(); // Post IDs whose data should not be overwritten (currently viewed posts)
   const processedPostDetailIds = new Set(); // Post detail responses already applied (avoid late duplicate overwrites)
   const pendingPostDetailIds = new Set(); // Post IDs currently being detail-fetched
+  const profileHandleToUserId = new Map(); // Observed profile handle -> user_id mappings
   let lastPostDetailUrlTemplate = null; // Remember a detail URL pattern to reuse across posts
   const charToOriginalIndex = new Map(); // Store original order from API
   let charGlobalIndexCounter = 0; // Global counter for character order across all API calls
@@ -171,6 +173,38 @@
       ensureUVDraftsPage();
       startUVDraftsTitleGuard();
     }
+  });
+
+  window.addEventListener('message', (ev) => {
+    if (ev?.source !== window) return;
+    const d = ev?.data;
+    if (!d || d.__sora_uv__ !== true || d.type !== 'cleanup_action_request') return;
+    const req = typeof d.req === 'string' ? d.req : '';
+    if (!req) return;
+    if (d.command !== 'bulk_unfollow') {
+      window.postMessage({
+        __sora_uv__: true,
+        type: 'cleanup_action_response',
+        req,
+        payload: { ok: false, error: 'Unknown cleanup action.' },
+      }, '*');
+      return;
+    }
+    handleCleanupActionRequest(d).then((payload) => {
+      window.postMessage({
+        __sora_uv__: true,
+        type: 'cleanup_action_response',
+        req,
+        payload: payload && typeof payload === 'object' ? payload : { ok: false, error: 'No cleanup action payload.' },
+      }, '*');
+    }).catch((err) => {
+      window.postMessage({
+        __sora_uv__: true,
+        type: 'cleanup_action_response',
+        req,
+        payload: { ok: false, error: err?.message || 'Cleanup action failed.' },
+      }, '*');
+    });
   });
 
   function getFallbackUVDraftsDocumentTitle() {
@@ -271,6 +305,9 @@
   let characterSortBtn = null;
   let characterSortMode = 'date'; // 'date', 'likes', 'cameos', 'likesPerDay'
   let charAutoLoadLastAttemptMs = 0;
+  let currentProfilePageHandle = null;
+  let currentProfilePageUserId = null;
+  let cleanupBulkActionInFlight = false;
   let suppressDetailBadgeRender = false; // Flag to prevent renderDetailBadge during bulk processing
   let badgeDataGeneration = 0; // Incremented when new metric data arrives; badges skip re-render when unchanged
   let renderPassInFlight = false; // Suppresses observer-triggered renders while processFeedJson is rendering
@@ -304,6 +341,8 @@
   const ANALYZE_WINDOW_KEY = 'SORA_UV_ANALYZE_WINDOW_H';
   let analyzeWindowHours = Math.min(24, Math.max(1, Number(localStorage.getItem(ANALYZE_WINDOW_KEY) || 24)));
   const ANALYZE_RUN_MS = 6500; // 6.5 seconds
+  const RELATIONSHIP_HARVEST_PAGE_SIZE = 20;
+  const RELATIONSHIP_HARVEST_MAX_PAGES = 150;
 
   // Bookmarks (Drafts page only)
   // 0 = show all, 1 = show bookmarked only, 2 = show unbookmarked only, 3 = violations only
@@ -342,6 +381,11 @@
     if (!Number.isFinite(x)) return '';
     return x.toLocaleString('en-US');
   };
+
+  const waitMs = (ms) =>
+    new Promise((resolve) => {
+      setTimeout(resolve, Math.max(0, Number(ms) || 0));
+    });
 
   function truncateInline(str, max = 140) {
     if (typeof str !== 'string') return '';
@@ -469,6 +513,30 @@
   function currentProfileHandleFromURL() {
     const m = location.pathname.match(/^\/profile\/(?:username\/)?([^\/?#]+)/i);
     return m ? m[1] : null;
+  }
+
+  function rememberObservedProfileIdentity(userHandle, userId) {
+    try {
+      const handle = typeof userHandle === 'string' ? userHandle.trim() : '';
+      const id = userId != null && userId !== '' ? String(userId) : '';
+      if (handle) currentProfilePageHandle = handle;
+      if (id) currentProfilePageUserId = id;
+      if (handle && id) profileHandleToUserId.set(handle.toLowerCase(), id);
+    } catch {}
+  }
+
+  function getCurrentProfilePageHandle() {
+    return currentProfileHandleFromURL() || currentProfilePageHandle || null;
+  }
+
+  function getCurrentProfileSubjectUserId() {
+    try {
+      const routeHandle = currentProfileHandleFromURL();
+      if (routeHandle) {
+        return profileHandleToUserId.get(routeHandle.toLowerCase()) || (currentProfilePageHandle && routeHandle.toLowerCase() === String(currentProfilePageHandle).toLowerCase() ? currentProfilePageUserId : null) || null;
+      }
+    } catch {}
+    return currentProfilePageUserId || null;
   }
 
   // == Data extraction ==
@@ -5539,15 +5607,19 @@ async function renderAnalyzeTable(force = false) {
           res.clone().json().then(processCharactersJson).catch((err) => {
             console.error('[SoraUV] Error parsing characters fetch response:', err);
           });
-        } else if (DRAFTS_RE.test(url)) {
-          decorateDraftsResponse(res);
-          res.clone().json().then(processDraftsJson).catch((err) => {
-            console.error('[SoraUV] Error parsing drafts fetch response:', err);
-          });
-        } else if (FEED_RE.test(url)) {
-          dlog('feed', 'fetch matched', { url });
-          res
-            .clone()
+	        } else if (DRAFTS_RE.test(url)) {
+	          decorateDraftsResponse(res);
+	          res.clone().json().then(processDraftsJson).catch((err) => {
+	            console.error('[SoraUV] Error parsing drafts fetch response:', err);
+	          });
+	        } else if (RELATIONSHIP_LIST_RE.test(url)) {
+	          res.clone().json().then((j) => {
+	            processRelationshipListJson(url, j);
+	          }).catch(() => {});
+	        } else if (FEED_RE.test(url)) {
+	          dlog('feed', 'fetch matched', { url });
+	          res
+	            .clone()
             .json()
             .then((j) => {
               dlog('feed', 'fetch parsed', { url, items: (j?.items || j?.data?.items || []).length });
@@ -5627,16 +5699,20 @@ async function renderAnalyzeTable(force = false) {
               } catch (err) {
                 console.error('[SoraUV] Error parsing characters XHR:', err);
               }
-            } else if (DRAFTS_RE.test(url)) {
-              try {
-                processDraftsJson(JSON.parse(this.responseText));
-              } catch (err) {
-                console.error('[SoraUV] Error parsing drafts XHR:', err);
-              }
-            } else if (FEED_RE.test(url)) {
-              dlog('feed', 'xhr matched', { url });
-              try {
-                const j = JSON.parse(this.responseText);
+	            } else if (DRAFTS_RE.test(url)) {
+	              try {
+	                processDraftsJson(JSON.parse(this.responseText));
+	              } catch (err) {
+	                console.error('[SoraUV] Error parsing drafts XHR:', err);
+	              }
+	            } else if (RELATIONSHIP_LIST_RE.test(url)) {
+	              try {
+	                processRelationshipListJson(url, JSON.parse(this.responseText));
+	              } catch {}
+	            } else if (FEED_RE.test(url)) {
+	              dlog('feed', 'xhr matched', { url });
+	              try {
+	                const j = JSON.parse(this.responseText);
                 dlog('feed', 'xhr parsed', { url, items: (j?.items || j?.data?.items || []).length });
                 processFeedJson(j);
               } catch {}
@@ -5710,9 +5786,121 @@ async function renderAnalyzeTable(force = false) {
     return null;
   }
 
+  function parseRelationshipListMeta(url) {
+    try {
+      const match = String(url || '').match(RELATIONSHIP_LIST_RE);
+      if (!match) return null;
+      const subjectUserId = match[1] ? String(match[1]) : null;
+      const listKind = match[2] ? String(match[2]).toLowerCase() : '';
+      if (!subjectUserId || (listKind !== 'followers' && listKind !== 'following')) return null;
+      return { subjectUserId, listKind };
+    } catch {}
+    return null;
+  }
+
+  function normalizeRelationshipUserKey(userHandle, userId) {
+    try {
+      const handle = typeof userHandle === 'string' ? userHandle.trim() : '';
+      if (handle) return `h:${handle.toLowerCase()}`;
+      if (userId != null && userId !== '') return `id:${String(userId)}`;
+    } catch {}
+    return null;
+  }
+
+  function toFiniteNumberOrNull(value) {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  }
+
+  function toBooleanOrNull(value) {
+    return typeof value === 'boolean' ? value : null;
+  }
+
+  function buildRelationshipGraphUser(raw) {
+    try {
+      if (!raw || typeof raw !== 'object') return null;
+      const userHandle = (typeof raw.username === 'string' ? raw.username.trim() : '') || null;
+      const userId = raw.user_id != null ? String(raw.user_id) : null;
+      const userKey = normalizeRelationshipUserKey(userHandle, userId);
+      if (!userKey) return null;
+      return {
+        user_key: userKey,
+        user_handle: userHandle,
+        user_id: userId,
+        display_name: (typeof raw.display_name === 'string' ? raw.display_name.trim() : '') || null,
+        follower_count: toFiniteNumberOrNull(raw.follower_count),
+        following_count: toFiniteNumberOrNull(raw.following_count),
+        post_count: toFiniteNumberOrNull(raw.post_count),
+        reply_count: toFiniteNumberOrNull(raw.reply_count),
+        likes_received_count: toFiniteNumberOrNull(raw.likes_received_count),
+        remix_count: toFiniteNumberOrNull(raw.remix_count),
+        cameo_count: toFiniteNumberOrNull(raw.cameo_count),
+        verified: toBooleanOrNull(raw.verified),
+        plan_type: (typeof raw.plan_type === 'string' ? raw.plan_type.trim() : '') || null,
+        permalink: (typeof raw.permalink === 'string' ? raw.permalink.trim() : '') || null,
+        can_cameo: toBooleanOrNull(raw.can_cameo),
+        created_at: toFiniteNumberOrNull(raw.created_at),
+        updated_at: toFiniteNumberOrNull(raw.updated_at),
+        description: (typeof raw.description === 'string' ? raw.description.trim() : '') || null,
+        location: (typeof raw.location === 'string' ? raw.location.trim() : '') || null,
+        follows_you: toBooleanOrNull(raw.follows_you),
+        is_following: toBooleanOrNull(raw.is_following),
+      };
+    } catch {}
+    return null;
+  }
+
+  function postRelationshipGraphSnapshot(meta, pageHandle, items, options = {}) {
+    try {
+      if (!meta) return;
+      const subjectUserKey = normalizeRelationshipUserKey(pageHandle, meta.subjectUserId);
+      if (!subjectUserKey) return;
+      const normalizedItems = Array.isArray(items) ? items.filter(Boolean) : [];
+      const replace = options?.replace === true;
+      if (!normalizedItems.length && !replace) return;
+      const payload = {
+        list_kind: meta.listKind,
+        items: normalizedItems,
+      };
+      const cursor = typeof options?.cursor === 'string' ? options.cursor : null;
+      if (cursor) payload.cursor = cursor;
+      if (replace) payload.replace = true;
+      window.postMessage({
+        __sora_uv__: true,
+        type: 'metrics_batch',
+        items: [{
+          ts: Date.now(),
+          userKey: subjectUserKey,
+          userHandle: pageHandle || null,
+          userId: meta.subjectUserId,
+          social_graph: payload,
+        }],
+      }, '*');
+    } catch {}
+  }
+
+  function processRelationshipListJson(url, json) {
+    try {
+      const meta = parseRelationshipListMeta(url);
+      if (!meta) return;
+      const pageHandle = isProfile() ? getCurrentProfilePageHandle() : null;
+      rememberObservedProfileIdentity(pageHandle, meta.subjectUserId);
+      const openDialog = findOpenRelationshipDialog();
+      if (openDialog) {
+        openDialog.dataset.soraUvRelationshipSubjectId = meta.subjectUserId;
+        openDialog.dataset.soraUvRelationshipLastListKind = meta.listKind;
+      }
+      const items = Array.isArray(json?.items) ? json.items.map(buildRelationshipGraphUser).filter(Boolean) : [];
+      postRelationshipGraphSnapshot(meta, pageHandle, items, {
+        cursor: typeof json?.cursor === 'string' ? json.cursor : null,
+      });
+    } catch {}
+  }
+
   function queueProfileSnapshot(batch, payload, pageUserHandle, pageUserKey){
     const snap = extractProfileSnapshot(payload, pageUserHandle, pageUserKey);
     if (!snap) return;
+    rememberObservedProfileIdentity(snap.userHandle, snap.userId);
     const base = {
       ts: Date.now(),
       userHandle: snap.userHandle,
@@ -5726,7 +5914,7 @@ async function renderAnalyzeTable(force = false) {
   }
 
   function processProfileJson(json){
-    const pageHandle = isProfile() ? currentProfileHandleFromURL() : null;
+    const pageHandle = isProfile() ? getCurrentProfilePageHandle() : null;
     const pageUserHandle = pageHandle || null;
     const pageUserKey = pageUserHandle ? `h:${pageUserHandle.toLowerCase()}` : 'unknown';
     const batch = [];
@@ -5740,7 +5928,7 @@ async function renderAnalyzeTable(force = false) {
 
   function processFeedJson(json) {
     const items = json?.items || json?.data?.items || [];
-    const pageHandle = isProfile() ? currentProfileHandleFromURL() : null;
+    const pageHandle = isProfile() ? getCurrentProfilePageHandle() : null;
     const pageUserHandle = pageHandle || null;
     const pageUserKey = pageUserHandle ? `h:${pageUserHandle.toLowerCase()}` : 'unknown';
     const batch = [];
@@ -6418,6 +6606,843 @@ async function renderAnalyzeTable(force = false) {
     renderCharacterStats();
   }
 
+  function normalizeRelationshipListKind(value) {
+    return value === 'followers' || value === 'following' ? value : null;
+  }
+
+  function normalizeDialogText(value) {
+    return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
+  }
+
+  function isRelationshipTabSelected(el) {
+    try {
+      if (!el) return false;
+      if (el.getAttribute('aria-selected') === 'true') return true;
+      if (el.getAttribute('aria-pressed') === 'true') return true;
+      const dataState = String(el.getAttribute('data-state') || '').toLowerCase();
+      if (dataState === 'active' || dataState === 'open' || dataState === 'on') return true;
+      if ((el.getAttribute('role') === 'tab' || el.hasAttribute('aria-controls')) && el.getAttribute('tabindex') === '0') return true;
+    } catch {}
+    return false;
+  }
+
+  function getRelationshipTabEntries(dialog) {
+    try {
+      if (!dialog || !dialog.isConnected) return [];
+      const dialogRect = dialog.getBoundingClientRect();
+      const topLimit = dialogRect.top + Math.min(220, Math.max(140, dialogRect.height * 0.3));
+      const seen = new Set();
+      const entries = [];
+      const addEntry = (el, container = null) => {
+        try {
+          if (!(el instanceof HTMLElement) || seen.has(el)) return;
+          const rect = el.getBoundingClientRect();
+          if (rect.width <= 0 || rect.height <= 0 || rect.top > topLimit) return;
+          const text = normalizeDialogText(el.textContent).toLowerCase();
+          if (!text || (!text.includes('followers') && !text.includes('following'))) return;
+          const kind = text.includes('following') ? 'following' : (text.includes('followers') ? 'followers' : null);
+          if (!kind) return;
+          seen.add(el);
+          entries.push({
+            el,
+            kind,
+            top: rect.top,
+            container: container || el.parentElement || null,
+          });
+        } catch {}
+      };
+
+      const tablists = Array.from(dialog.querySelectorAll('[role="tablist"]'))
+        .filter((el) => {
+          try {
+            if (!(el instanceof HTMLElement)) return false;
+            const rect = el.getBoundingClientRect();
+            return rect.width > 0 && rect.height > 0 && rect.top <= topLimit;
+          } catch {}
+          return false;
+        })
+        .sort((a, b) => a.getBoundingClientRect().top - b.getBoundingClientRect().top);
+
+      for (const tablist of tablists) {
+        Array.from(tablist.querySelectorAll('[role="tab"], button')).forEach((el) => addEntry(el, tablist));
+      }
+      if (entries.length) {
+        return entries.sort((a, b) => a.top - b.top);
+      }
+
+      Array.from(dialog.querySelectorAll('button, [role="tab"], [aria-selected], [aria-pressed]')).forEach((el) => addEntry(el));
+      return entries.sort((a, b) => a.top - b.top);
+    } catch {}
+    return [];
+  }
+
+  function getRelationshipDialogInfo(dialog) {
+    try {
+      if (!dialog || !dialog.isConnected) return null;
+      const entries = getRelationshipTabEntries(dialog);
+      if (!entries.length) return null;
+
+      const followersEntry = entries
+        .filter((entry) => entry.kind === 'followers')
+        .sort((a, b) => a.top - b.top)[0] || null;
+      const followingEntry = entries
+        .filter((entry) => entry.kind === 'following')
+        .sort((a, b) => a.top - b.top)[0] || null;
+
+      const tabs = {
+        followers: followersEntry?.el || null,
+        following: followingEntry?.el || null,
+      };
+      let selectedKind = entries.find((entry) => isRelationshipTabSelected(entry.el))?.kind || null;
+      if (!selectedKind) {
+        selectedKind = normalizeRelationshipListKind(String(dialog.dataset.soraUvRelationshipLastListKind || '').toLowerCase());
+      }
+      if (!selectedKind) {
+        if (tabs.following && !tabs.followers) selectedKind = 'following';
+        else if (tabs.followers && !tabs.following) selectedKind = 'followers';
+      }
+
+      const anchorEntry = entries.find((entry) => entry.kind === selectedKind) || followersEntry || followingEntry || null;
+      const anchor = anchorEntry?.el || tabs[selectedKind] || tabs.followers || tabs.following;
+      return {
+        selectedKind,
+        tabs,
+        headerContainer: anchorEntry?.container || anchor?.parentElement || dialog,
+      };
+    } catch {}
+    return null;
+  }
+
+  function findOpenRelationshipDialog() {
+    const dialogs = Array.from(document.querySelectorAll('div[role="dialog"][data-state="open"], div[role="dialog"]'));
+    for (const dialog of dialogs) {
+      if (getRelationshipDialogInfo(dialog)) return dialog;
+    }
+    return null;
+  }
+
+  function resolveRelationshipDialog(dialog) {
+    try {
+      const info = getRelationshipDialogInfo(dialog);
+      if (info) return { dialog, info };
+    } catch {}
+    try {
+      const liveDialog = findOpenRelationshipDialog();
+      if (liveDialog) {
+        const info = getRelationshipDialogInfo(liveDialog);
+        if (info) return { dialog: liveDialog, info };
+      }
+    } catch {}
+    return { dialog, info: null };
+  }
+
+  function countRelationshipRows(dialog) {
+    try {
+      const hrefs = new Set();
+      dialog.querySelectorAll('a[href^="/profile/"]').forEach((link) => {
+        const href = typeof link.getAttribute === 'function' ? link.getAttribute('href') || '' : '';
+        if (href) hrefs.add(href);
+      });
+      return hrefs.size;
+    } catch {}
+    return 0;
+  }
+
+  function findRelationshipListScroller(dialog) {
+    try {
+      const firstLink = dialog.querySelector('a[href^="/profile/"]');
+      let node = firstLink?.parentElement || null;
+      while (node && node !== dialog) {
+        try {
+          const style = getComputedStyle(node);
+          if (node.scrollHeight > node.clientHeight + 4 && (style.overflowY === 'auto' || style.overflowY === 'scroll')) {
+            return node;
+          }
+        } catch {}
+        node = node.parentElement;
+      }
+
+      const explicitScroller = dialog.querySelector('.overflow-y-auto');
+      if (explicitScroller && explicitScroller.scrollHeight > explicitScroller.clientHeight + 4) return explicitScroller;
+
+      const descendants = Array.from(dialog.querySelectorAll('*'));
+      for (const el of descendants) {
+        try {
+          if (!(el instanceof HTMLElement)) continue;
+          const style = getComputedStyle(el);
+          if (el.scrollHeight > el.clientHeight + 4 && (style.overflowY === 'auto' || style.overflowY === 'scroll')) {
+            return el;
+          }
+        } catch {}
+      }
+    } catch {}
+    return null;
+  }
+
+  function waitForRelationshipRowCountChange(dialog, prevCount, timeoutMs) {
+    return new Promise((resolve) => {
+      let done = false;
+      const finish = (count) => {
+        if (done) return;
+        done = true;
+        try {
+          obs.disconnect();
+        } catch {}
+        try {
+          clearTimeout(timer);
+        } catch {}
+        resolve(count);
+      };
+      const obs = new MutationObserver(() => {
+        try {
+          const next = countRelationshipRows(dialog);
+          if (next !== prevCount) finish(next);
+        } catch {}
+      });
+      try {
+        obs.observe(dialog, { childList: true, subtree: true });
+      } catch {}
+      const timer = setTimeout(() => finish(countRelationshipRows(dialog)), timeoutMs);
+    });
+  }
+
+  async function waitForRelationshipListScroller(dialog, timeoutMs = 12000) {
+    const deadline = Date.now() + Math.max(1000, Number(timeoutMs) || 0);
+    while (Date.now() < deadline) {
+      const scroller = findRelationshipListScroller(dialog);
+      if (scroller) return scroller;
+      await waitMs(150);
+    }
+    return findRelationshipListScroller(dialog);
+  }
+
+  function setRelationshipHarvestStatus(dialog, text, tone = 'muted') {
+    try {
+      const liveDialog = resolveRelationshipDialog(dialog)?.dialog || dialog;
+      const statusEl = liveDialog?.querySelector('.sora-uv-relationship-harvest-status');
+      if (!statusEl) return;
+      statusEl.textContent = text || '';
+      const colors = {
+        muted: 'rgba(255,255,255,0.68)',
+        busy: '#facc15',
+        success: '#86efac',
+        warn: '#fde68a',
+        danger: '#fca5a5',
+      };
+      statusEl.style.color = colors[tone] || colors.muted;
+    } catch {}
+  }
+
+  function setRelationshipHarvestButtonsBusy(dialog, busy) {
+    try {
+      const liveDialog = resolveRelationshipDialog(dialog)?.dialog || dialog;
+      liveDialog?.querySelectorAll('.sora-uv-relationship-harvest-btn').forEach((btn) => {
+        btn.disabled = !!busy;
+        btn.style.opacity = busy ? '0.6' : '1';
+        btn.style.cursor = busy ? 'wait' : 'pointer';
+      });
+    } catch {}
+  }
+
+  function buildRelationshipListUrl(subjectUserId, listKind, cursor) {
+    const url = new URL(`${location.origin}/backend/project_y/${encodeURIComponent(String(subjectUserId || ''))}/${listKind}/user_listing`);
+    url.searchParams.set('limit', String(RELATIONSHIP_HARVEST_PAGE_SIZE));
+    if (cursor) url.searchParams.set('cursor', cursor);
+    return url.toString();
+  }
+
+  function resolveRelationshipSubjectUserId(dialog) {
+    const dialogValue = dialog?.dataset?.soraUvRelationshipSubjectId;
+    if (dialogValue) return dialogValue;
+    return getCurrentProfileSubjectUserId();
+  }
+
+  async function waitForRelationshipSubjectUserId(dialog, timeoutMs = 1600) {
+    const deadline = Date.now() + Math.max(250, Number(timeoutMs) || 0);
+    while (Date.now() < deadline) {
+      const subjectUserId = resolveRelationshipSubjectUserId(dialog);
+      if (subjectUserId) return subjectUserId;
+      await waitMs(120);
+    }
+    return resolveRelationshipSubjectUserId(dialog);
+  }
+
+  async function fetchRelationshipListPage(subjectUserId, listKind, cursor) {
+    const headers = { Accept: 'application/json' };
+    if (capturedAuthToken) headers.Authorization = capturedAuthToken;
+    return fetch(buildRelationshipListUrl(subjectUserId, listKind, cursor), {
+      method: 'GET',
+      credentials: 'include',
+      cache: 'no-store',
+      headers,
+    });
+  }
+
+  async function harvestRelationshipListViaApi(dialog, listKind) {
+    const subjectUserId = await waitForRelationshipSubjectUserId(dialog, 1800);
+    if (!subjectUserId) throw new Error('Profile id not ready for API harvesting yet.');
+    const pageHandle = isProfile() ? getCurrentProfilePageHandle() : null;
+    const harvestMeta = { subjectUserId, listKind };
+
+    let cursor = null;
+    let pageCount = 0;
+    let totalItems = 0;
+    const seenCursors = new Set();
+    const harvestedItems = new Map();
+
+    while (pageCount < RELATIONSHIP_HARVEST_MAX_PAGES) {
+      setRelationshipHarvestStatus(dialog, `Harvesting ${listKind} via API… page ${pageCount + 1}`, 'busy');
+      const res = await fetchRelationshipListPage(subjectUserId, listKind, cursor);
+      if (!res.ok) throw new Error(`API returned ${res.status} for ${listKind}.`);
+      const json = await res.json();
+      const rawItems = Array.isArray(json?.items) ? json.items : [];
+      const items = rawItems.map(buildRelationshipGraphUser).filter(Boolean);
+      totalItems += items.length;
+      for (const item of items) {
+        if (item?.user_key) harvestedItems.set(item.user_key, item);
+      }
+      pageCount += 1;
+      dialog.dataset.soraUvRelationshipSubjectId = subjectUserId;
+      dialog.dataset.soraUvRelationshipLastListKind = listKind;
+
+      const nextCursor = typeof json?.cursor === 'string' && json.cursor ? json.cursor : null;
+      if (!nextCursor || rawItems.length === 0 || seenCursors.has(nextCursor)) break;
+      seenCursors.add(nextCursor);
+      cursor = nextCursor;
+      await waitMs(140);
+    }
+
+    postRelationshipGraphSnapshot(harvestMeta, pageHandle, Array.from(harvestedItems.values()), {
+      replace: true,
+    });
+
+    return { mode: 'api', listKind, totalItems, pageCount };
+  }
+
+  async function harvestRelationshipListViaScroll(dialog, listKind) {
+    const scroller = findRelationshipListScroller(dialog);
+    if (!scroller) throw new Error('Could not find a scrollable follower list.');
+
+    const startTop = scroller.scrollTop;
+    let prevCount = countRelationshipRows(dialog);
+    let stableRounds = 0;
+
+    for (let i = 0; i < 36; i++) {
+      if (!dialog.isConnected) break;
+      setRelationshipHarvestStatus(dialog, `Harvesting ${listKind} by scrolling… ${fmtInt(prevCount)} rows`, 'busy');
+      const prevTop = scroller.scrollTop;
+      scroller.scrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight - 1);
+      scroller.scrollTop = scroller.scrollHeight;
+      if (scroller.scrollTop === prevTop) {
+        scroller.scrollTop = Math.max(0, prevTop - 1);
+        scroller.scrollTop = scroller.scrollHeight;
+      }
+      try {
+        scroller.dispatchEvent(new Event('scroll'));
+      } catch {}
+
+      const nextCount = await waitForRelationshipRowCountChange(dialog, prevCount, 1400);
+      if (nextCount > prevCount) {
+        prevCount = nextCount;
+        stableRounds = 0;
+        continue;
+      }
+      stableRounds += 1;
+      if (stableRounds >= 3) break;
+    }
+
+    scroller.scrollTop = startTop;
+    return { mode: 'scroll', listKind, totalItems: prevCount, pageCount: null };
+  }
+
+  function clickRelationshipTab(tab) {
+    try {
+      if (!(tab instanceof HTMLElement)) return false;
+      try {
+        tab.focus({ preventScroll: true });
+      } catch {}
+      try {
+        tab.click();
+        return true;
+      } catch {}
+      try {
+        tab.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, composed: true, view: window }));
+        return true;
+      } catch {}
+    } catch {}
+    return false;
+  }
+
+  async function switchRelationshipDialogTab(dialog, listKind) {
+    let resolved = resolveRelationshipDialog(dialog);
+    let liveDialog = resolved.dialog || dialog;
+    let info = resolved.info || getRelationshipDialogInfo(liveDialog);
+    if (!info) return false;
+    if (info.selectedKind === listKind) {
+      try {
+        liveDialog.dataset.soraUvRelationshipLastListKind = listKind;
+      } catch {}
+      try {
+        dialog.dataset.soraUvRelationshipLastListKind = listKind;
+      } catch {}
+      return true;
+    }
+
+    const target = info.tabs[listKind];
+    if (!target) return false;
+
+    const prevCount = countRelationshipRows(liveDialog);
+    if (!clickRelationshipTab(target)) return false;
+
+    for (let i = 0; i < 48; i++) {
+      await waitMs(160);
+      resolved = resolveRelationshipDialog(liveDialog);
+      liveDialog = resolved.dialog || liveDialog || dialog;
+      const nextInfo = resolved.info || getRelationshipDialogInfo(liveDialog);
+      const nextTarget = nextInfo?.tabs?.[listKind] || null;
+      if (nextInfo?.selectedKind === listKind || isRelationshipTabSelected(nextTarget)) {
+        try {
+          liveDialog.dataset.soraUvRelationshipLastListKind = listKind;
+        } catch {}
+        try {
+          dialog.dataset.soraUvRelationshipLastListKind = listKind;
+        } catch {}
+        return true;
+      }
+      const rememberedKind = normalizeRelationshipListKind(String(
+        liveDialog?.dataset?.soraUvRelationshipLastListKind || dialog?.dataset?.soraUvRelationshipLastListKind || ''
+      ).toLowerCase());
+      if (rememberedKind === listKind) return true;
+      if (i >= 4 && countRelationshipRows(liveDialog) !== prevCount) return true;
+      if (i === 8 && nextTarget) {
+        clickRelationshipTab(nextTarget);
+      }
+    }
+    return false;
+  }
+
+  async function harvestRelationshipListHybrid(dialog, listKind) {
+    try {
+      return await harvestRelationshipListViaApi(dialog, listKind);
+    } catch (apiErr) {
+      setRelationshipHarvestStatus(dialog, `API harvest for ${listKind} failed, falling back to scroll…`, 'warn');
+      const scrollResult = await harvestRelationshipListViaScroll(dialog, listKind);
+      scrollResult.apiError = apiErr?.message || String(apiErr || '');
+      return scrollResult;
+    }
+  }
+
+  async function harvestRelationshipDialog(dialog, scope) {
+    try {
+      if (!dialog || !dialog.isConnected) return;
+      if (dialog.dataset.soraUvRelationshipHarvestRunning === '1') return;
+      dialog.dataset.soraUvRelationshipHarvestRunning = '1';
+      setRelationshipHarvestButtonsBusy(dialog, true);
+
+      const info = getRelationshipDialogInfo(dialog);
+      if (!info) {
+        setRelationshipHarvestStatus(dialog, 'Open a Followers or Following modal first.', 'danger');
+        return;
+      }
+
+      const lastKind = normalizeRelationshipListKind(String(dialog.dataset.soraUvRelationshipLastListKind || '').toLowerCase());
+      const currentKind = info.selectedKind || lastKind || (info.tabs.following ? 'following' : (info.tabs.followers ? 'followers' : null));
+      const kinds = scope === 'both'
+        ? Array.from(new Set([currentKind, 'following', 'followers'].filter(Boolean)))
+        : [currentKind].filter(Boolean);
+
+      if (!kinds.length) {
+        setRelationshipHarvestStatus(dialog, 'Could not tell which relationship list is open.', 'danger');
+        return;
+      }
+
+      const originalKind = currentKind;
+      const results = [];
+
+      for (const kind of kinds) {
+        if (!dialog.isConnected) break;
+        const ready = await switchRelationshipDialogTab(dialog, kind);
+        if (!ready) {
+          results.push({ listKind: kind, error: `Could not switch to ${kind}.` });
+          continue;
+        }
+        try {
+          results.push(await harvestRelationshipListHybrid(dialog, kind));
+        } catch (err) {
+          results.push({ listKind: kind, error: err?.message || String(err || '') });
+        }
+      }
+
+      if (scope === 'both' && originalKind && kinds[kinds.length - 1] !== originalKind) {
+        try {
+          await switchRelationshipDialogTab(dialog, originalKind);
+        } catch {}
+      }
+
+      const okResults = results.filter((result) => !result.error);
+      const failedResults = results.filter((result) => !!result.error);
+      if (!okResults.length) {
+        setRelationshipHarvestStatus(dialog, failedResults[0]?.error || 'Relationship harvest failed.', 'danger');
+        return;
+      }
+
+      const summary = okResults
+        .map((result) => `${fmtInt(result.totalItems)} ${result.listKind} (${result.mode})`)
+        .join(' • ');
+      const tone = failedResults.length ? 'warn' : 'success';
+      const suffix = failedResults.length ? ` • ${failedResults[0].error}` : '';
+      setRelationshipHarvestStatus(dialog, `Captured ${summary}${suffix}`, tone);
+    } catch (err) {
+      setRelationshipHarvestStatus(dialog, err?.message || 'Relationship harvest failed.', 'danger');
+    } finally {
+      try {
+        delete dialog.dataset.soraUvRelationshipHarvestRunning;
+      } catch {}
+      setRelationshipHarvestButtonsBusy(dialog, false);
+    }
+  }
+
+  function renderRelationshipHarvestControls() {
+    const dialog = findOpenRelationshipDialog();
+    if (!dialog) return;
+    if (dialog.querySelector('.sora-uv-relationship-harvest-controls')) return;
+
+    const info = getRelationshipDialogInfo(dialog);
+    if (!info) return;
+
+    const controls = document.createElement('div');
+    controls.className = 'sora-uv-relationship-harvest-controls';
+    Object.assign(controls.style, {
+      display: 'flex',
+      flexWrap: 'wrap',
+      alignItems: 'center',
+      gap: '8px',
+      marginTop: '8px',
+    });
+
+    const makeActionButton = (label, scope) => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'sora-uv-relationship-harvest-btn';
+      btn.textContent = label;
+      Object.assign(btn.style, {
+        background: 'rgba(29,29,29,0.82)',
+        color: '#fff',
+        border: '1px solid rgba(255,255,255,0.14)',
+        borderRadius: '999px',
+        padding: '6px 12px',
+        fontSize: '12px',
+        fontWeight: '600',
+        cursor: 'pointer',
+        whiteSpace: 'nowrap',
+      });
+      btn.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        harvestRelationshipDialog(dialog, scope);
+      });
+      return btn;
+    };
+
+    const status = document.createElement('div');
+    status.className = 'sora-uv-relationship-harvest-status';
+    status.setAttribute('role', 'status');
+    Object.assign(status.style, {
+      fontSize: '12px',
+      color: 'rgba(255,255,255,0.68)',
+      minHeight: '18px',
+    });
+    status.textContent = 'Uses the Sora API when available, otherwise scrolls the list for you.';
+
+    controls.appendChild(makeActionButton('Harvest current', 'current'));
+    controls.appendChild(makeActionButton('Harvest both', 'both'));
+    controls.appendChild(status);
+
+    const anchor = info.headerContainer || dialog.firstElementChild || dialog;
+    if (anchor.parentElement) {
+      anchor.insertAdjacentElement('afterend', controls);
+    } else {
+      dialog.prepend(controls);
+    }
+  }
+
+  function normalizeCleanupHandle(value) {
+    return typeof value === 'string' ? value.trim().replace(/^@/, '').toLowerCase() : '';
+  }
+
+  function extractCleanupHandleFromHref(href) {
+    try {
+      const match = String(href || '').match(/^\/profile\/([^/?#]+)/i);
+      if (!match || !match[1]) return '';
+      return normalizeCleanupHandle(decodeURIComponent(match[1]));
+    } catch {}
+    return '';
+  }
+
+  function findRelationshipActionRow(link, dialog) {
+    try {
+      if (!(link instanceof HTMLElement)) return null;
+      let node = link.parentElement || null;
+      while (node && node !== dialog) {
+        const buttons = Array.from(node.querySelectorAll('button'))
+          .filter((btn) => {
+            const text = normalizeDialogText(btn.textContent).toLowerCase();
+            return text === 'following' || text === 'follow back' || text === 'follow';
+          });
+        if (buttons.length) {
+          return { row: node, button: buttons[0] };
+        }
+        node = node.parentElement;
+      }
+    } catch {}
+    return null;
+  }
+
+  function collectRelationshipActionRows(dialog) {
+    const seen = new Set();
+    const rows = [];
+    try {
+      dialog.querySelectorAll('a[href^="/profile/"]').forEach((link) => {
+        const href = typeof link.getAttribute === 'function' ? link.getAttribute('href') || '' : '';
+        const handle = extractCleanupHandleFromHref(href);
+        if (!handle || seen.has(handle)) return;
+        const rowInfo = findRelationshipActionRow(link, dialog);
+        if (!rowInfo?.button) return;
+        seen.add(handle);
+        rows.push({
+          handle,
+          link,
+          row: rowInfo.row,
+          button: rowInfo.button,
+          buttonText: normalizeDialogText(rowInfo.button.textContent).toLowerCase(),
+        });
+      });
+    } catch {}
+    return rows;
+  }
+
+  function findProfileRelationshipTrigger(listKind) {
+    try {
+      const dialogs = new Set(Array.from(document.querySelectorAll('div[role="dialog"]')));
+      const candidates = Array.from(document.querySelectorAll('button, [role="button"], [role="tab"]'))
+        .filter((el) => {
+          if (!(el instanceof HTMLElement)) return false;
+          for (const dialog of dialogs) {
+            if (dialog.contains(el)) return false;
+          }
+          const text = normalizeDialogText(el.textContent).toLowerCase();
+          if (!text || !text.includes(listKind)) return false;
+          const rect = el.getBoundingClientRect();
+          return rect.width > 0 && rect.height > 0 && rect.top < Math.max(360, window.innerHeight * 0.5);
+        })
+        .sort((a, b) => a.getBoundingClientRect().top - b.getBoundingClientRect().top);
+      return candidates[0] || null;
+    } catch {}
+    return null;
+  }
+
+  async function waitForProfileRelationshipTrigger(listKind, timeoutMs = 12000) {
+    const deadline = Date.now() + Math.max(1000, Number(timeoutMs) || 0);
+    while (Date.now() < deadline) {
+      const trigger = findProfileRelationshipTrigger(listKind);
+      if (trigger) return trigger;
+      await waitMs(150);
+    }
+    return findProfileRelationshipTrigger(listKind);
+  }
+
+  async function waitForRelationshipDialogTrigger(listKind, timeoutMs = 12000) {
+    const normalizedKind = normalizeRelationshipListKind(listKind);
+    if (!normalizedKind) return null;
+    const fallbackKind = normalizedKind === 'following' ? 'followers' : 'following';
+    const deadline = Date.now() + Math.max(1000, Number(timeoutMs) || 0);
+    while (Date.now() < deadline) {
+      const direct = findProfileRelationshipTrigger(normalizedKind);
+      if (direct) return direct;
+      const fallback = findProfileRelationshipTrigger(fallbackKind);
+      if (fallback) return fallback;
+      await waitMs(150);
+    }
+    return findProfileRelationshipTrigger(normalizedKind) || findProfileRelationshipTrigger(fallbackKind);
+  }
+
+  async function waitForRelationshipDialogOpen(timeoutMs = 12000) {
+    const deadline = Date.now() + Math.max(1000, Number(timeoutMs) || 0);
+    while (Date.now() < deadline) {
+      const dialog = findOpenRelationshipDialog();
+      if (dialog) return dialog;
+      await waitMs(120);
+    }
+    return findOpenRelationshipDialog();
+  }
+
+  async function ensureCleanupProfileRoute(profileHandle) {
+    try {
+      const normalizedTarget = normalizeCleanupHandle(profileHandle);
+      const currentHandle = normalizeCleanupHandle(getCurrentProfilePageHandle() || currentProfileHandleFromURL() || '');
+      if (isProfile() && (!normalizedTarget || currentHandle === normalizedTarget)) return true;
+      const nextPath = normalizedTarget ? `/profile/${encodeURIComponent(normalizedTarget)}` : '/profile';
+      try {
+        history.pushState({}, '', nextPath);
+        onRouteChange();
+      } catch {
+        location.href = nextPath;
+      }
+      const deadline = Date.now() + 18000;
+      while (Date.now() < deadline) {
+        const handle = normalizeCleanupHandle(getCurrentProfilePageHandle() || currentProfileHandleFromURL() || '');
+        if (isProfile() && (!normalizedTarget || handle === normalizedTarget)) return true;
+        await waitMs(150);
+      }
+    } catch {}
+    return false;
+  }
+
+  async function openRelationshipDialogForKind(listKind) {
+    const normalizedKind = normalizeRelationshipListKind(listKind);
+    if (!normalizedKind) throw new Error('Unknown relationship list type.');
+    let resolved = resolveRelationshipDialog(findOpenRelationshipDialog());
+    let dialog = resolved?.dialog || null;
+    if (dialog && resolved?.info) {
+      if (await switchRelationshipDialogTab(dialog, normalizedKind)) {
+        renderRelationshipHarvestControls();
+        return resolveRelationshipDialog(dialog).dialog || dialog;
+      }
+    }
+    const trigger = await waitForRelationshipDialogTrigger(normalizedKind, 12000);
+    if (!trigger) throw new Error(`Could not find the ${normalizedKind} button on the profile page.`);
+    try {
+      trigger.click();
+    } catch {
+      throw new Error(`Could not open the ${normalizedKind} dialog.`);
+    }
+    dialog = await waitForRelationshipDialogOpen(12000);
+    if (!dialog) throw new Error(`Timed out waiting for the ${normalizedKind} dialog.`);
+    renderRelationshipHarvestControls();
+    if (!(await switchRelationshipDialogTab(dialog, normalizedKind))) {
+      throw new Error(`Could not switch to the ${normalizedKind} tab.`);
+    }
+    return resolveRelationshipDialog(dialog).dialog || dialog;
+  }
+
+  async function clickRelationshipFollowToggle(button, timeoutMs = 5000) {
+    const before = normalizeDialogText(button?.textContent).toLowerCase();
+    if (!button || before !== 'following') return false;
+    try {
+      button.click();
+    } catch {
+      return false;
+    }
+    const deadline = Date.now() + Math.max(1000, Number(timeoutMs) || 0);
+    while (Date.now() < deadline) {
+      if (!(button instanceof HTMLElement) || !button.isConnected) return true;
+      const next = normalizeDialogText(button.textContent).toLowerCase();
+      if (next && next !== 'following') return true;
+      await waitMs(120);
+    }
+    return false;
+  }
+
+  async function executeBulkUnfollowInDialog(dialog, targets) {
+    const targetHandles = new Set((Array.isArray(targets) ? targets : []).map((item) => normalizeCleanupHandle(item?.userHandle)).filter(Boolean));
+    if (!targetHandles.size) return { ok: false, error: 'No valid following handles were selected.' };
+    const scroller = await waitForRelationshipListScroller(dialog, 12000);
+    if (!scroller) throw new Error('Could not find the Following list scroller.');
+
+    const unfollowed = [];
+    const skipped = [];
+    const pending = new Set(targetHandles);
+    let stableRounds = 0;
+
+    try {
+      scroller.scrollTop = 0;
+    } catch {}
+    await waitMs(180);
+
+    for (let round = 0; round < 320 && pending.size; round++) {
+      const visibleRows = collectRelationshipActionRows(dialog);
+      let matchedThisRound = false;
+      for (const row of visibleRows) {
+        if (!pending.has(row.handle)) continue;
+        matchedThisRound = true;
+        pending.delete(row.handle);
+        if (row.buttonText === 'following') {
+          setRelationshipHarvestStatus(dialog, `Unfollowing @${row.handle}...`, 'busy');
+          const ok = await clickRelationshipFollowToggle(row.button, 6500);
+          if (ok) unfollowed.push(row.handle);
+          else skipped.push(row.handle);
+          await waitMs(220);
+        } else {
+          skipped.push(row.handle);
+        }
+      }
+      if (!pending.size) break;
+
+      const beforeTop = scroller.scrollTop;
+      const beforeCount = countRelationshipRows(dialog);
+      scroller.scrollTop = Math.min(scroller.scrollHeight, scroller.scrollTop + Math.max(240, scroller.clientHeight - 72));
+      try {
+        scroller.dispatchEvent(new Event('scroll'));
+      } catch {}
+      const nextCount = await waitForRelationshipRowCountChange(dialog, beforeCount, 900);
+      const afterTop = scroller.scrollTop;
+      if (!matchedThisRound && nextCount === beforeCount && Math.abs(afterTop - beforeTop) < 4) {
+        stableRounds += 1;
+      } else {
+        stableRounds = 0;
+      }
+      if (stableRounds >= 3) break;
+    }
+
+    const notFound = Array.from(pending);
+    const tone = notFound.length ? 'warn' : 'success';
+    setRelationshipHarvestStatus(
+      dialog,
+      `Unfollowed ${fmtInt(unfollowed.length)} selected${skipped.length ? ` • ${fmtInt(skipped.length)} skipped` : ''}${notFound.length ? ` • ${fmtInt(notFound.length)} not found` : ''}`,
+      tone
+    );
+    return {
+      ok: true,
+      unfollowed: unfollowed.length,
+      skipped: skipped.length,
+      notFound: notFound.length,
+      unfollowedHandles: unfollowed,
+      skippedHandles: skipped,
+      notFoundHandles: notFound,
+    };
+  }
+
+  async function handleCleanupActionRequest(request) {
+    if (cleanupBulkActionInFlight) {
+      return { ok: false, error: 'A cleanup action is already running in this tab.' };
+    }
+    cleanupBulkActionInFlight = true;
+    try {
+      const payload = request?.payload || {};
+      const targets = Array.isArray(payload?.targets) ? payload.targets : [];
+      if (!(await ensureCleanupProfileRoute(payload?.profileHandle || ''))) {
+        throw new Error('Could not open the requested Sora profile before unfollowing.');
+      }
+      const dialog = await openRelationshipDialogForKind('following');
+      if (!dialog) throw new Error('Could not open the Following dialog.');
+      if (dialog.dataset.soraUvRelationshipHarvestRunning === '1') {
+        throw new Error('Wait for the current relationship harvest to finish before bulk unfollowing.');
+      }
+      setRelationshipHarvestButtonsBusy(dialog, true);
+      dialog.dataset.soraUvRelationshipBulkActionRunning = '1';
+      return await executeBulkUnfollowInDialog(dialog, targets);
+    } finally {
+      cleanupBulkActionInFlight = false;
+      try {
+        const dialog = findOpenRelationshipDialog();
+        if (dialog) {
+          delete dialog.dataset.soraUvRelationshipBulkActionRunning;
+          setRelationshipHarvestButtonsBusy(dialog, false);
+        }
+      } catch {}
+    }
+  }
+
   function scheduleEnsureAllCharactersLoadedInDialog(dialog) {
     try {
       if (!dialog || !dialog.isConnected) return;
@@ -6990,7 +8015,10 @@ async function renderAnalyzeTable(force = false) {
       renderDraftButtons();
     }
     // Character stats only matters on profile/characters views; it does its own internal gating.
-    if (location.pathname.includes('/profile')) renderCharacterStats();
+    if (location.pathname.includes('/profile')) {
+      renderCharacterStats();
+      renderRelationshipHarvestControls();
+    }
     updateControlsVisibility();
     scheduleInjectDashboardButton();
   }
@@ -7320,6 +8348,20 @@ async function renderAnalyzeTable(force = false) {
     }
 
     if (navigated) {
+      if (isProfile()) {
+        const routeHandle = currentProfileHandleFromURL();
+        if (routeHandle) {
+          currentProfilePageHandle = routeHandle;
+          currentProfilePageUserId = profileHandleToUserId.get(routeHandle.toLowerCase()) || null;
+        } else {
+          currentProfilePageHandle = null;
+          currentProfilePageUserId = null;
+        }
+      } else {
+        currentProfilePageHandle = null;
+        currentProfilePageUserId = null;
+      }
+
       forceStopGatherOnNavigation();
       if (!shouldPreserveFilterAcrossNavigation(prev, rk)) resetFilterOnNavigation();
       // Reset bookmarks filter on navigation

--- a/tests/background-cleanup-tab-routing.regression.test.js
+++ b/tests/background-cleanup-tab-routing.regression.test.js
@@ -1,0 +1,141 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const BACKGROUND_PATH = path.join(__dirname, '..', 'background.js');
+
+function extractSnippet(source, startMarker, endMarker, label) {
+  const start = source.indexOf(startMarker);
+  assert.notEqual(start, -1, `${label} start not found`);
+  const end = source.indexOf(endMarker, start);
+  assert.notEqual(end, -1, `${label} end not found`);
+  return source.slice(start, end);
+}
+
+function buildCleanupTabHarness({ queryMap = {}, updateResults = {}, getResults = {} } = {}) {
+  const src = fs.readFileSync(BACKGROUND_PATH, 'utf8');
+  const snippet = extractSnippet(
+    src,
+    'function queryTabs(queryInfo) {',
+    'async function dispatchCleanupBulkUnfollow(request) {',
+    'background cleanup tab routing snippet'
+  );
+
+  const calls = {
+    query: [],
+    update: [],
+    create: [],
+    get: [],
+    addListener: 0,
+    removeListener: 0,
+  };
+
+  const onUpdatedListeners = new Set();
+  const chrome = {
+    runtime: { lastError: null },
+    tabs: {
+      query(queryInfo, callback) {
+        calls.query.push(queryInfo);
+        const key = JSON.stringify(queryInfo);
+        callback(Array.isArray(queryMap[key]) ? queryMap[key] : []);
+      },
+      update(tabId, updateProperties, callback) {
+        calls.update.push({ tabId, updateProperties });
+        callback(updateResults[String(tabId)] || { id: tabId, ...updateProperties });
+      },
+      create(createProperties, callback) {
+        calls.create.push(createProperties);
+        callback({ id: 999, ...createProperties, status: 'loading' });
+      },
+      get(tabId, callback) {
+        calls.get.push(tabId);
+        callback(getResults[String(tabId)] || { id: tabId, status: 'complete' });
+      },
+      onUpdated: {
+        addListener(fn) {
+          calls.addListener += 1;
+          onUpdatedListeners.add(fn);
+        },
+        removeListener(fn) {
+          calls.removeListener += 1;
+          onUpdatedListeners.delete(fn);
+        },
+      },
+    },
+  };
+
+  const context = {
+    chrome,
+    URL,
+    setTimeout,
+    clearTimeout,
+  };
+  vm.createContext(context);
+  vm.runInContext(
+    `${snippet}\nglobalThis.__findOrOpenCleanupTab = findOrOpenCleanupTab;`,
+    context,
+    { filename: 'background-cleanup-tab-routing.harness.js' }
+  );
+
+  return {
+    calls,
+    findOrOpenCleanupTab: context.__findOrOpenCleanupTab,
+  };
+}
+
+test('findOrOpenCleanupTab reuses an exact matching profile tab without rewriting its URL', async () => {
+  const harness = buildCleanupTabHarness({
+    queryMap: {
+      [JSON.stringify({ active: true, lastFocusedWindow: true, url: 'https://sora.chatgpt.com/*' })]: [],
+      [JSON.stringify({ url: 'https://sora.chatgpt.com/profile*' })]: [
+        { id: 41, url: 'https://sora.chatgpt.com/profile/aidaredevils', status: 'complete' },
+        { id: 42, url: 'https://sora.chatgpt.com/profile', status: 'complete' },
+      ],
+    },
+    updateResults: {
+      '41': { id: 41, url: 'https://sora.chatgpt.com/profile/aidaredevils', status: 'complete', active: true },
+    },
+  });
+
+  const result = await harness.findOrOpenCleanupTab('aidaredevils');
+
+  assert.equal(result?.id, 41);
+  assert.deepEqual(JSON.parse(JSON.stringify(harness.calls.update)), [
+    { tabId: 41, updateProperties: { active: true } },
+  ]);
+  assert.deepEqual(harness.calls.create, []);
+});
+
+test('findOrOpenCleanupTab retargets an existing Sora tab to the requested profile before messaging it', async () => {
+  const harness = buildCleanupTabHarness({
+    queryMap: {
+      [JSON.stringify({ active: true, lastFocusedWindow: true, url: 'https://sora.chatgpt.com/*' })]: [],
+      [JSON.stringify({ url: 'https://sora.chatgpt.com/profile*' })]: [
+        { id: 55, url: 'https://sora.chatgpt.com/profile', status: 'complete' },
+      ],
+      [JSON.stringify({ url: 'https://sora.chatgpt.com/*' })]: [
+        { id: 55, url: 'https://sora.chatgpt.com/profile', status: 'complete' },
+      ],
+    },
+    updateResults: {
+      '55': { id: 55, url: 'https://sora.chatgpt.com/profile/simeo', status: 'loading', active: true },
+    },
+    getResults: {
+      '55': { id: 55, url: 'https://sora.chatgpt.com/profile/simeo', status: 'complete', active: true },
+    },
+  });
+
+  const result = await harness.findOrOpenCleanupTab('simeo');
+
+  assert.equal(result?.id, 55);
+  assert.deepEqual(JSON.parse(JSON.stringify(harness.calls.update)), [
+    {
+      tabId: 55,
+      updateProperties: { active: true, url: 'https://sora.chatgpt.com/profile/simeo' },
+    },
+  ]);
+  assert.deepEqual(harness.calls.get, [55]);
+  assert.equal(harness.calls.create.length, 0);
+});

--- a/tests/background-relationship-graph.regression.test.js
+++ b/tests/background-relationship-graph.regression.test.js
@@ -1,0 +1,97 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const BACKGROUND_PATH = path.join(__dirname, '..', 'background.js');
+
+function extractSnippet(source, startMarker, endMarker, label) {
+  const start = source.indexOf(startMarker);
+  assert.notEqual(start, -1, `${label} start not found`);
+  const end = source.indexOf(endMarker, start);
+  assert.notEqual(end, -1, `${label} end not found`);
+  return source.slice(start, end);
+}
+
+function buildRelationshipGraphHarness() {
+  const src = fs.readFileSync(BACKGROUND_PATH, 'utf8');
+  const snippet = extractSnippet(
+    src,
+    'function isPlainObject(value) {',
+    'function normalizeMetrics(raw) {',
+    'background relationship graph snippet'
+  );
+  const context = {};
+  vm.createContext(context);
+  vm.runInContext(
+    `${snippet}\nglobalThis.__upsertRelationshipGraph = upsertRelationshipGraph;`,
+    context,
+    { filename: 'background-relationship-graph.harness.js' }
+  );
+  assert.equal(typeof context.__upsertRelationshipGraph, 'function');
+  return context.__upsertRelationshipGraph;
+}
+
+test('upsertRelationshipGraph replace payload prunes stale following edges', () => {
+  const upsertRelationshipGraph = buildRelationshipGraphHarness();
+  const userEntry = {
+    relationshipGraph: {
+      nodes: {
+        'h:keep': { user_key: 'h:keep', user_handle: 'keep', lastSeenAt: 1700000000000 },
+        'h:remove': { user_key: 'h:remove', user_handle: 'remove', lastSeenAt: 1700000000000 },
+      },
+      edges: {
+        followers: {},
+        following: {
+          'h:keep': { user_key: 'h:keep', user_handle: 'keep', is_following: true, follows_you: false, seenAt: 1700000000000 },
+          'h:remove': { user_key: 'h:remove', user_handle: 'remove', is_following: true, follows_you: false, seenAt: 1700000000000 },
+        },
+      },
+    },
+  };
+
+  const changed = upsertRelationshipGraph(userEntry, {
+    list_kind: 'following',
+    replace: true,
+    items: [
+      {
+        user_key: 'h:keep',
+        user_handle: 'keep',
+        user_id: 'user-keep',
+        follower_count: 1,
+        follows_you: false,
+        is_following: true,
+      },
+    ],
+  }, 1700005000000);
+
+  assert.equal(changed, true);
+  assert.deepEqual(Object.keys(userEntry.relationshipGraph.edges.following), ['h:keep']);
+  assert.equal(userEntry.relationshipGraph.fullSyncAt.following, 1700005000000);
+});
+
+test('upsertRelationshipGraph replace payload can clear a following bucket entirely', () => {
+  const upsertRelationshipGraph = buildRelationshipGraphHarness();
+  const userEntry = {
+    relationshipGraph: {
+      nodes: {},
+      edges: {
+        followers: {},
+        following: {
+          'h:remove': { user_key: 'h:remove', user_handle: 'remove', is_following: true, follows_you: false, seenAt: 1700000000000 },
+        },
+      },
+    },
+  };
+
+  const changed = upsertRelationshipGraph(userEntry, {
+    list_kind: 'following',
+    replace: true,
+    items: [],
+  }, 1700008000000);
+
+  assert.equal(changed, true);
+  assert.deepEqual(Object.keys(userEntry.relationshipGraph.edges.following), []);
+  assert.equal(userEntry.relationshipGraph.fullSyncAt.following, 1700008000000);
+});

--- a/tests/dashboard-cleanup-planner.regression.test.js
+++ b/tests/dashboard-cleanup-planner.regression.test.js
@@ -1,0 +1,242 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const DASHBOARD_PATH = path.join(__dirname, '..', 'dashboard.js');
+
+function extractCleanupSnippet() {
+  const src = fs.readFileSync(DASHBOARD_PATH, 'utf8');
+  const start = src.indexOf('function cloneRelationshipGraphNode(node) {');
+  assert.notEqual(start, -1, 'cleanup snippet start not found');
+  const end = src.indexOf('function clearCleanupPlannerList(el, emptyText) {', start);
+  assert.notEqual(end, -1, 'cleanup snippet end not found');
+  return src.slice(start, end);
+}
+
+function buildCleanupHarness() {
+  const snippet = extractCleanupSnippet();
+  const context = {};
+  const bootstrap = `
+    const CLEANUP_PANEL_FILTER_DEFAULTS = { pageSize: 25 };
+    function toTs(v){
+      if (typeof v === 'number' && Number.isFinite(v)) return v < 1e11 ? v * 1000 : v;
+      if (typeof v === 'string' && v.trim()) {
+        const s = v.trim();
+        if (/^\\d+(?:\\.\\d+)?$/.test(s)) {
+          const n = Number(s);
+          return n < 1e11 ? n * 1000 : n;
+        }
+        const d = Date.parse(s);
+        if (!Number.isNaN(d)) return d;
+      }
+      return 0;
+    }
+    ${snippet}
+    globalThis.__buildCleanupPlannerModel = buildCleanupPlannerModel;
+    globalThis.__mergeRelationshipGraphs = mergeRelationshipGraphs;
+    globalThis.__filterCleanupPlannerItems = filterCleanupPlannerItems;
+    globalThis.__paginateCleanupPlannerItems = paginateCleanupPlannerItems;
+  `;
+  vm.createContext(context);
+  vm.runInContext(bootstrap, context, { filename: 'dashboard-cleanup-planner.harness.js' });
+  return {
+    buildCleanupPlannerModel: context.__buildCleanupPlannerModel,
+    mergeRelationshipGraphs: context.__mergeRelationshipGraphs,
+    filterCleanupPlannerItems: context.__filterCleanupPlannerItems,
+    paginateCleanupPlannerItems: context.__paginateCleanupPlannerItems,
+  };
+}
+
+test('mergeRelationshipGraphs keeps latest node stats while preserving both edge directions', () => {
+  const { mergeRelationshipGraphs } = buildCleanupHarness();
+  const merged = mergeRelationshipGraphs([
+    {
+      nodes: {
+        'h:bob': { user_key: 'h:bob', user_handle: 'bob', follower_count: 12, updated_at: 1700000000, lastSeenAt: 1700000000000 },
+      },
+      edges: {
+        followers: {},
+        following: {
+          'h:bob': { user_key: 'h:bob', is_following: true, follows_you: false, seenAt: 1700000000000 },
+        },
+      },
+    },
+    {
+      nodes: {
+        'h:bob': { user_key: 'h:bob', user_handle: 'bob', follower_count: 25, updated_at: 1700003600, lastSeenAt: 1700005000000 },
+      },
+      edges: {
+        followers: {
+          'h:bob': { user_key: 'h:bob', is_following: false, follows_you: true, seenAt: 1700005000000 },
+        },
+        following: {},
+      },
+    },
+  ]);
+  assert.ok(merged);
+  assert.equal(merged.nodes['h:bob'].follower_count, 25);
+  assert.equal(merged.edges.following['h:bob'].is_following, true);
+  assert.equal(merged.edges.followers['h:bob'].follows_you, true);
+});
+
+test('buildCleanupPlannerModel surfaces non-mutual low-signal following accounts first', () => {
+  const { buildCleanupPlannerModel } = buildCleanupHarness();
+  const now = Date.UTC(2026, 2, 22);
+  const user = {
+    relationshipGraph: {
+      nodes: {
+        'h:inactive': {
+          user_key: 'h:inactive',
+          user_handle: 'inactive',
+          follower_count: 8,
+          post_count: 3,
+          likes_received_count: 12,
+          updated_at: Math.floor((now - 90 * 24 * 60 * 60 * 1000) / 1000),
+          permalink: 'https://sora.chatgpt.com/profile/inactive',
+        },
+        'h:creator': {
+          user_key: 'h:creator',
+          user_handle: 'creator',
+          follower_count: 5400,
+          post_count: 220,
+          likes_received_count: 48000,
+          updated_at: Math.floor((now - 2 * 24 * 60 * 60 * 1000) / 1000),
+          verified: true,
+          permalink: 'https://sora.chatgpt.com/profile/creator',
+        },
+      },
+      edges: {
+        followers: {
+          'h:creator': {
+            user_key: 'h:creator',
+            follows_you: true,
+            is_following: false,
+            seenAt: now - 1000,
+          },
+        },
+        following: {
+          'h:inactive': {
+            user_key: 'h:inactive',
+            follows_you: false,
+            is_following: true,
+            seenAt: now - 1000,
+          },
+          'h:creator': {
+            user_key: 'h:creator',
+            follows_you: true,
+            is_following: true,
+            seenAt: now - 1000,
+          },
+        },
+      },
+    },
+  };
+
+  const plan = buildCleanupPlannerModel(user, {
+    maxFollowers: 200,
+    minPosts: 12,
+    staleDays: 45,
+    minLikesReceived: 120,
+    maxRows: 10,
+  }, now);
+
+  assert.equal(plan.summary.followingCaptured, 2);
+  assert.equal(plan.summary.mutualCount, 1);
+  assert.equal(plan.following[0].userKey, 'h:inactive');
+  assert.equal(plan.following[0].recommendation, 'Unfollow likely');
+  assert.ok(plan.following[0].reasons.some((reason) => reason.label === 'not following you back'));
+  assert.ok(plan.following.every((item) => item.userKey !== 'h:creator' || item.score < plan.following[0].score));
+});
+
+test('buildCleanupPlannerModel marks exact zero-signal following accounts for one-click selection', () => {
+  const { buildCleanupPlannerModel } = buildCleanupHarness();
+  const now = Date.UTC(2026, 2, 23);
+  const user = {
+    relationshipGraph: {
+      nodes: {
+        'h:ghost': {
+          user_key: 'h:ghost',
+          user_handle: 'ghost',
+          follower_count: 0,
+          post_count: 0,
+          likes_received_count: 0,
+          updated_at: Math.floor((now - 131 * 24 * 60 * 60 * 1000) / 1000),
+          permalink: 'https://sora.chatgpt.com/profile/ghost',
+        },
+      },
+      edges: {
+        followers: {},
+        following: {
+          'h:ghost': {
+            user_key: 'h:ghost',
+            user_handle: 'ghost',
+            follows_you: false,
+            is_following: true,
+            seenAt: now - 1000,
+          },
+        },
+      },
+    },
+  };
+
+  const plan = buildCleanupPlannerModel(user, {
+    maxFollowers: 200,
+    minPosts: 12,
+    staleDays: 45,
+    minLikesReceived: 120,
+  }, now);
+
+  assert.equal(plan.summary.zeroSignalFollowingCount, 1);
+  assert.equal(plan.following[0].userKey, 'h:ghost');
+  assert.equal(plan.following[0].zeroSignal, true);
+  assert.equal(plan.following[0].nonMutual, true);
+  assert.equal(plan.following[0].inactive, true);
+});
+
+test('filterCleanupPlannerItems supports reason and status filtering before pagination', () => {
+  const { filterCleanupPlannerItems, paginateCleanupPlannerItems } = buildCleanupHarness();
+  const items = [
+    { userKey: 'h:alpha', userHandle: 'alpha', displayName: 'Alpha', score: 82, nonMutual: true, lowFollowers: true, lowPosts: true, lowLikes: true, inactive: true, zeroSignal: true, verified: false, followerCount: 0, postCount: 0, likesReceivedCount: 0, inactiveDays: 90 },
+    { userKey: 'h:beta', userHandle: 'beta', displayName: 'Beta', score: 61, nonMutual: true, lowFollowers: false, lowPosts: false, lowLikes: false, inactive: false, verified: false, followerCount: 250, postCount: 45, inactiveDays: 5 },
+    { userKey: 'h:creator', userHandle: 'creator', displayName: 'Creator', score: 18, nonMutual: false, lowFollowers: false, lowPosts: false, lowLikes: false, inactive: false, verified: true, followerCount: 5000, postCount: 240, inactiveDays: 1 },
+  ];
+
+  const filtered = filterCleanupPlannerItems(items, {
+    search: 'a',
+    status: 'actionable',
+    reason: 'non_mutual',
+    sort: 'followers_asc',
+  }, 'following');
+  assert.deepEqual(filtered.map((item) => item.userKey), ['h:alpha', 'h:beta']);
+
+  const page = paginateCleanupPlannerItems(filtered, 2, 1);
+  assert.equal(page.totalPages, 2);
+  assert.equal(page.page, 2);
+  assert.deepEqual(page.items.map((item) => item.userKey), ['h:beta']);
+
+  const zeroSignal = filterCleanupPlannerItems(items, {
+    search: '',
+    status: 'all',
+    reason: 'zero_signal',
+    sort: 'score_desc',
+  }, 'following');
+  assert.deepEqual(zeroSignal.map((item) => item.userKey), ['h:alpha']);
+
+  const smartUnfollow = filterCleanupPlannerItems(items, {
+    search: '',
+    status: 'actionable',
+    reason: 'smart_unfollow',
+    sort: 'score_desc',
+  }, 'following');
+  assert.deepEqual(smartUnfollow.map((item) => item.userKey), ['h:alpha']);
+
+  const lowLikes = filterCleanupPlannerItems(items, {
+    search: '',
+    status: 'all',
+    reason: 'low_likes',
+    sort: 'likes_asc',
+  }, 'following');
+  assert.deepEqual(lowLikes.map((item) => item.userKey), ['h:alpha']);
+});

--- a/tests/dashboard-user-resolution.regression.test.js
+++ b/tests/dashboard-user-resolution.regression.test.js
@@ -414,3 +414,156 @@ test('buildMergedIdentityUser merges followers from multiple alias buckets by ti
   assert.equal(c.length, 3, 'should merge 3 unique cameo timestamps');
   assert.equal(c[2].count, 8, 'most recent cameo from new handle should be present');
 });
+
+test('buildMergedIdentityUser merges relationship graphs across alias buckets', () => {
+  const { buildMergedIdentityUser, setMetrics } = buildResolutionHarness();
+  const metrics = {
+    users: {
+      'id:user-1': {
+        id: 'user-1',
+        handle: 'alice',
+        posts: { p1: { snapshots: [{ t: 1700000000000, views: 1 }] } },
+        relationshipGraph: {
+          nodes: {
+            'h:bob': {
+              user_key: 'h:bob',
+              user_handle: 'bob',
+              follower_count: 12,
+              post_count: 4,
+              likes_received_count: 20,
+              updated_at: 1700000000,
+            },
+          },
+          edges: {
+            followers: {},
+            following: {
+              'h:bob': {
+                user_key: 'h:bob',
+                user_handle: 'bob',
+                follows_you: false,
+                is_following: true,
+                seenAt: 1700000000000,
+              },
+            },
+          },
+        },
+      },
+      'h:alice': {
+        id: 'user-1',
+        handle: 'alice',
+        posts: {},
+        relationshipGraph: {
+          nodes: {
+            'h:bob': {
+              user_key: 'h:bob',
+              user_handle: 'bob',
+              follower_count: 18,
+              post_count: 7,
+              likes_received_count: 35,
+              updated_at: 1700003600,
+            },
+            'h:carol': {
+              user_key: 'h:carol',
+              user_handle: 'carol',
+              follower_count: 90,
+              post_count: 44,
+              likes_received_count: 900,
+              updated_at: 1700010000,
+            },
+          },
+          edges: {
+            followers: {
+              'h:bob': {
+                user_key: 'h:bob',
+                user_handle: 'bob',
+                follows_you: true,
+                is_following: false,
+                seenAt: 1700005000000,
+              },
+            },
+            following: {},
+          },
+        },
+      },
+    },
+  };
+  setMetrics(metrics);
+  const merged = buildMergedIdentityUser(metrics, 'id:user-1', metrics.users['id:user-1']);
+  assert.ok(merged?.user?.relationshipGraph, 'merged user should include relationship graph');
+  assert.equal(Object.keys(merged.user.relationshipGraph.nodes || {}).length, 2);
+  assert.equal(Object.keys(merged.user.relationshipGraph.edges.following || {}).length, 1);
+  assert.equal(Object.keys(merged.user.relationshipGraph.edges.followers || {}).length, 1);
+  assert.equal(merged.user.relationshipGraph.nodes['h:bob'].follower_count, 18, 'latest node data should win');
+  assert.equal(merged.user.relationshipGraph.edges.followers['h:bob'].follows_you, true);
+  assert.equal(merged.user.relationshipGraph.edges.following['h:bob'].is_following, true);
+});
+
+test('buildMergedIdentityUser drops stale alias following edges after a newer full sync', () => {
+  const { buildMergedIdentityUser, setMetrics } = buildResolutionHarness();
+  const metrics = {
+    users: {
+      'id:user-1': {
+        id: 'user-1',
+        handle: 'alice',
+        posts: {},
+        relationshipGraph: {
+          nodes: {
+            'h:stale': {
+              user_key: 'h:stale',
+              user_handle: 'stale',
+              follower_count: 2,
+              updated_at: 1700000000,
+            },
+          },
+          edges: {
+            followers: {},
+            following: {
+              'h:stale': {
+                user_key: 'h:stale',
+                user_handle: 'stale',
+                follows_you: false,
+                is_following: true,
+                seenAt: 1700000000000,
+              },
+            },
+          },
+        },
+      },
+      'h:alice': {
+        id: 'user-1',
+        handle: 'alice',
+        posts: {},
+        relationshipGraph: {
+          nodes: {
+            'h:keep': {
+              user_key: 'h:keep',
+              user_handle: 'keep',
+              follower_count: 4,
+              updated_at: 1700003600,
+            },
+          },
+          edges: {
+            followers: {},
+            following: {
+              'h:keep': {
+                user_key: 'h:keep',
+                user_handle: 'keep',
+                follows_you: false,
+                is_following: true,
+                seenAt: 1700005000000,
+              },
+            },
+          },
+          fullSyncAt: {
+            following: 1700005000000,
+          },
+        },
+      },
+    },
+  };
+  setMetrics(metrics);
+  const merged = buildMergedIdentityUser(metrics, 'id:user-1', metrics.users['id:user-1']);
+  assert.ok(merged?.user?.relationshipGraph, 'merged user should include relationship graph');
+  assert.deepEqual(Object.keys(merged.user.relationshipGraph.edges.following || {}), ['h:keep']);
+  assert.equal(merged.user.relationshipGraph.fullSyncAt.following, 1700005000000);
+});

--- a/tests/metrics-key-sanitization.regression.test.js
+++ b/tests/metrics-key-sanitization.regression.test.js
@@ -130,3 +130,61 @@ test('sanitizers still reject payloads with no metrics signal', () => {
     null
   );
 });
+
+test('sanitizers accept social graph payloads as a standalone signal', () => {
+  const sanitizeMetricsItem = buildContentSanitizerHarness();
+  const sanitizeMetricsSnapshot = buildBackgroundSanitizerHarness();
+  const raw = {
+    userId: 'user-123',
+    social_graph: {
+      list_kind: 'following',
+      items: [
+        {
+          user_handle: 'bob',
+          user_id: 'user-456',
+          follower_count: 12,
+          post_count: 4,
+          follows_you: false,
+          is_following: true,
+        },
+      ],
+    },
+  };
+  const contentOut = sanitizeMetricsItem(raw);
+  const backgroundOut = sanitizeMetricsSnapshot(raw);
+  assert.ok(contentOut);
+  assert.ok(backgroundOut);
+  assert.equal(contentOut.userKey, 'id:user-123');
+  assert.equal(backgroundOut.userKey, 'id:user-123');
+  assert.equal(contentOut.social_graph.list_kind, 'following');
+  assert.equal(backgroundOut.social_graph.list_kind, 'following');
+  assert.equal(contentOut.social_graph.items[0].user_key, 'h:bob');
+  assert.equal(backgroundOut.social_graph.items[0].user_key, 'h:bob');
+  assert.equal(contentOut.social_graph.items[0].follows_you, false);
+  assert.equal(backgroundOut.social_graph.items[0].is_following, true);
+});
+
+test('sanitizers preserve social graph replace payloads even when the harvested list is empty', () => {
+  const sanitizeMetricsItem = buildContentSanitizerHarness();
+  const sanitizeMetricsSnapshot = buildBackgroundSanitizerHarness();
+  const raw = {
+    userId: 'user-123',
+    social_graph: {
+      list_kind: 'following',
+      replace: true,
+      items: [],
+    },
+  };
+  const contentOut = sanitizeMetricsItem(raw);
+  const backgroundOut = sanitizeMetricsSnapshot(raw);
+  assert.ok(contentOut);
+  assert.ok(backgroundOut);
+  assert.equal(contentOut.social_graph.list_kind, 'following');
+  assert.equal(backgroundOut.social_graph.list_kind, 'following');
+  assert.equal(contentOut.social_graph.replace, true);
+  assert.equal(backgroundOut.social_graph.replace, true);
+  assert.equal(Array.isArray(contentOut.social_graph.items), true);
+  assert.equal(Array.isArray(backgroundOut.social_graph.items), true);
+  assert.equal(contentOut.social_graph.items.length, 0);
+  assert.equal(backgroundOut.social_graph.items.length, 0);
+});


### PR DESCRIPTION
## Summary
- Add a Followers & Following cleanup workspace to the dashboard.
- Harvest relationship data so the extension can map followers and following accounts together.
- Surface non-mutual and low-signal accounts to make cleanup decisions easier.
- Guide bulk unfollow actions through Sora's native UI instead of relying on the dashboard to guess tabs.
- Update README copy and local artifact ignores to match the feature work.

## Verification
- `node --test tests/*.test.js` (159 passing)
- `for f in *.js tests/*.js; do node --check "$f"; done`
- `git diff --check`

## Notes
- This PR keeps the cleanup flow local-first and within the existing Sora/OpenAI extension behavior.
- A manual in-Chrome smoke test of the new cleanup workspace is still the main follow-up before merge.
